### PR TITLE
docs: add owner-aligned architecture plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# StratusScan-Azure Agent Guide
+
+This repo follows the cross-provider StratusScan product contract in
+`stratusscan-philosophy.md`. Read that file before proposing or making product
+changes. `CLAUDE.md` contains the Azure-specific implementation guide and should
+be treated as authoritative for local architecture.
+
+## Product Boundaries
+
+- StratusScan is a terminal-based, menu-driven inventory exporter.
+- It is not a monitoring system, cost-management platform, security scanner,
+  web app, API server, daemon, or background service.
+- It must remain read-only against cloud accounts. Never add resource creation,
+  modification, or deletion.
+- Output is Excel workbooks (`.xlsx`) for human review, filtering, sharing, and
+  audit evidence.
+- Cloud Shell compatibility is a primary requirement. Keep runtime dependencies
+  minimal and pip-installable in a fresh Azure Cloud Shell session.
+- Public and US Government cloud support are first-class. Detect cloud context
+  from the active Azure environment and skip unavailable services gracefully.
+
+## Azure Architecture Rules
+
+- `stratusscan_azure.py` is a thin terminal menu and subprocess launcher.
+  It must not call Azure APIs directly.
+- Each exporter in `scripts/` must run independently via
+  `python scripts/<name>.py`.
+- Shared code lives in `sslib/` and must not print to the console. Use
+  module-scoped `logging` and return structured data.
+- Only CLI entry points, `configure.py`, and exporter scripts may print user
+  messages.
+- Always get credentials through `sslib.auth.get_credential()`.
+- Call `quiet_azure_loggers()` near the start of exporter `main()` functions.
+- Use `detect_cloud()`, `graph_scope_for_cloud()`, and `arm_client_kwargs()` for
+  cloud-aware Azure SDK and Microsoft Graph access.
+- Load scan scope from `config.json` via `load_config()` and
+  `filter_subscription_ids()`.
+- Export files through `make_filename()` and `save_dataframes()` only. Do not
+  hardcode output paths or filenames.
+- Each workbook should put a `Summary` sheet first, with row counts and
+  per-scope errors recorded as rows instead of crashing the whole export.
+- Put `Tags` last in row schemas.
+
+## Naming And Style
+
+- Script filenames use `lowercase_underscored.py`; never hyphens.
+- Output filenames follow the repo helper convention:
+  `{SCOPE}-{exporter}-{suffix}-export-{MM.DD.YYYY}.xlsx`.
+- Tenant and subscription labels come from config mappings, never hardcoded.
+- Keep comments sparse. Prefer clear names; add comments only for non-obvious
+  constraints or SDK behavior.
+- Follow the existing `ruff` and `black` configuration.
+
+## Scope Guardrails
+
+Do not introduce:
+
+- Web UIs, local web servers, API servers, or persistent services.
+- Live pricing API calls during export runs. Use committed static reference data
+  only when pricing estimates are supported.
+- Proprietary or compiled runtime dependencies.
+- Credentials in code, templates, docs, or committed config.
+- Multi-CSP dispatch logic inside this Azure repo. Shared philosophy is fine;
+  shared runtime code is not.

--- a/docs/owner-aligned-refactor-plan.md
+++ b/docs/owner-aligned-refactor-plan.md
@@ -1,0 +1,377 @@
+# Owner-Aligned Refactor Plan
+
+This plan turns the work from the closed PR branches into small, reviewable
+changes that match the StratusScan product philosophy and the repo owner's
+architecture requirements.
+
+## Goal
+
+Preserve the valuable technical work from the rejected PRs while restoring the
+architecture the owner asked for:
+
+- Terminal-only, menu-driven CLI.
+- One independently runnable exporter script per resource or focused category.
+- One exporter produces one scoped `.xlsx` workbook.
+- `stratusscan_azure.py` stays a thin subprocess launcher.
+- Resource Graph is allowed as an implementation detail inside targeted
+  exporters.
+- No monolithic "everything" workbook as the primary user workflow.
+- No HTML reports or parallel artifact types.
+- No resource modification, credential storage, daemon, API server, or web UI.
+
+## What We Learned From The Closed PRs
+
+### PR #4: `sslib` foundation and broad Resource Graph export
+
+Owner feedback:
+
+- The `sslib/` refactor has good ideas, but it was bundled into too large a
+  structural rewrite.
+- Replacing many per-resource exporters with one broad `resource_graph_export.py`
+  removes targeted-export behavior.
+- The right model is still one script per resource or category, even if those
+  scripts use Resource Graph KQL internally.
+
+Salvage:
+
+- Cloud-aware auth and endpoint helpers.
+- Output filename and workbook helpers.
+- Subscription filtering concepts.
+- Resource Graph KQL patterns.
+- Smoke-test patterns.
+
+Do not salvage:
+
+- The monolithic Resource Graph workbook as the main inventory model.
+- Deletion of existing per-resource exporters in the same PR as new foundation
+  work.
+
+### PR #5: Flattened NSG rules
+
+Owner feedback:
+
+- The flattened NSG rule data is valuable and auditor-aligned.
+- It should be a standalone `network_security_groups_export.py`, not a bonus
+  sheet inside a broad Resource Graph workbook.
+
+Salvage:
+
+- KQL that unions custom and default NSG security rules.
+- Row schema for priority, direction, access, protocol, source/destination, and
+  ports.
+
+### PR #6: FinOps waste and tag coverage
+
+Owner feedback:
+
+- Orphaned resources, stale snapshots, tag coverage, and untagged resources are
+  useful.
+- They should be a standalone `finops_export.py`, not extra sheets appended to
+  a full-tenant inventory workbook.
+
+Salvage:
+
+- KQL for orphaned disks, unassigned public IPs, orphaned NICs, stale snapshots,
+  tag coverage, and untagged resources.
+
+### PR #7: Cost findings HTML report
+
+Owner feedback:
+
+- HTML output does not fit StratusScan. Findings belong in workbooks.
+- The owner corrected the initial objection to Cost Management API calls:
+  Azure Cost Management data is acceptable when implemented as a standard
+  exporter.
+- A `cost_management_export.py` that queries Cost Management and writes `.xlsx`
+  would be a good focused PR.
+
+Salvage:
+
+- Cost Management Query API implementation.
+- US Gov routing fix using `timeframe=Custom` with explicit `timePeriod`.
+- Graceful handling for subscriptions without Cost Management permissions.
+
+Do not salvage:
+
+- HTML report generation.
+- Auto-generating sidecar artifacts during unrelated exporters.
+
+## Branching Strategy
+
+The rejected branches should be treated as source material only.
+
+For every new PR:
+
+```bash
+git fetch origin
+git switch dev
+git pull --ff-only origin dev
+git switch -c feature/<small-focused-slug>
+```
+
+Then copy or cherry-pick only the narrow code needed for that PR.
+
+Do not base new PRs on:
+
+- `feature/cost-findings-report`
+- `feature/cost-addons`
+- `feature/security-addons`
+- `sslib-foundation`
+- any branch that deletes the existing per-resource exporter structure
+
+## PR Acceptance Criteria
+
+Every PR must satisfy:
+
+- It targets `dev`.
+- It has one primary purpose.
+- It preserves existing exporter granularity unless the PR is explicitly adding
+  one new targeted exporter.
+- Any new exporter can run directly with `python scripts/<path>.py`.
+- The main menu only launches the exporter as a subprocess.
+- Output is an `.xlsx` workbook written through the repo's output helper or the
+  existing local pattern.
+- Errors are recorded in a `Summary` sheet or human-readable CLI message instead
+  of crashing the whole run where partial export is possible.
+- Azure calls are read-only.
+- Public and US Gov clouds are either supported or unavailable services are
+  skipped cleanly with a logged reason.
+- Runtime dependencies remain Cloud Shell-friendly and minimal.
+- Tests or smoke checks cover importability and menu registration where
+  practical.
+
+## Proposed PR Sequence
+
+### PR 1: Document the owner contract
+
+Purpose:
+
+- Add `stratusscan-philosophy.md`.
+- Add `AGENTS.md`.
+- Align existing agent/contributor docs so future work follows the same
+  architecture.
+
+Allowed changes:
+
+- Documentation only.
+
+Not allowed:
+
+- Runtime refactors.
+- Exporter changes.
+
+Validation:
+
+- Markdown review.
+- Confirm no runtime files changed.
+
+### PR 2: Minimal shared helpers, if needed
+
+Purpose:
+
+- Introduce only the shared helpers required to support focused exporters
+  without duplicating auth, cloud, output, or subscription logic.
+
+Candidate scope:
+
+- `sslib.auth.get_credential()`
+- `sslib.cloud.detect_cloud()`
+- `sslib.cloud.arm_client_kwargs()`
+- `sslib.output.make_filename()`
+- `sslib.output.save_dataframes()`
+- `sslib.subscriptions` filtering helpers
+
+Rules:
+
+- Keep the PR small.
+- Do not rewrite every existing exporter in this PR.
+- Do not remove existing exporters.
+- Do not add feature behavior beyond enabling future exporters.
+- No `print()` in shared library code.
+
+Validation:
+
+- Smoke import tests for new shared modules.
+- Manual menu startup.
+
+### PR 3: Standalone NSG rules exporter
+
+Purpose:
+
+- Implement flattened NSG rule export in the owner-approved shape.
+
+File target:
+
+- `scripts/network/network_security_groups_export.py`
+
+Behavior:
+
+- Runs directly.
+- Uses Resource Graph KQL internally.
+- Produces a dedicated NSG workbook.
+- Includes custom and default rules.
+- Keeps audit-relevant columns: subscription, resource group, NSG name,
+  location, rule type, rule name, priority, direction, access, protocol,
+  source/destination prefixes, source/destination ports, ASGs, description, ID.
+
+Menu:
+
+- Register or preserve the menu item for Network Security Groups.
+
+Validation:
+
+- Import smoke test.
+- Dry/manual run against an Azure tenant if credentials are available.
+- Confirm workbook has `Summary` first and rule detail sheet after.
+
+### PR 4: Standalone FinOps signal exporter
+
+Purpose:
+
+- Add a focused FinOps workbook based on inventory-derived waste and governance
+  signals.
+
+File target:
+
+- `scripts/finops_export.py`
+
+Sheets:
+
+- `Summary`
+- `Orphaned Resources`
+- `Stale Snapshots`
+- `Tag Coverage`
+- `Untagged Resources`
+
+Behavior:
+
+- Uses Resource Graph KQL only.
+- Requires no billing permissions.
+- Does not claim exact dollar savings.
+- Uses descriptive, pivot-friendly columns.
+
+Menu:
+
+- Add a top-level menu item for FinOps signals.
+
+Validation:
+
+- Import smoke test.
+- Manual run where possible.
+- Confirm no new runtime dependencies.
+
+### PR 5: Standalone Cost Management exporter
+
+Purpose:
+
+- Add actual billed-cost export in the owner-approved workbook shape.
+
+File target:
+
+- `scripts/cost_management_export.py`
+
+Optional helper:
+
+- `sslib/cost_management.py`, if not already introduced in PR 2.
+
+Behavior:
+
+- Queries Azure Cost Management read-only API.
+- Writes `.xlsx`, not HTML.
+- Uses active cloud ARM endpoint and scope.
+- Uses `timeframe=Custom` with explicit previous-month `timePeriod` for gov
+  cloud compatibility.
+- Handles subscriptions without Cost Management access by recording the error in
+  `Summary` and continuing.
+
+Sheets:
+
+- `Summary`
+- `Costs By Resource`
+- Optional: `Costs By Subscription`
+- Optional: `Costs By Resource Group`
+
+Menu:
+
+- Add a top-level menu item for Cost Management.
+
+Validation:
+
+- Import smoke test.
+- Manual run in at least one tenant.
+- Confirm subscriptions without permissions do not fail the whole export.
+
+### PR 6+: Resource Graph-backed targeted exporter modernization
+
+Purpose:
+
+- Improve existing per-resource exporters one at a time by using Resource Graph
+  internally while preserving their targeted script and workbook contract.
+
+Candidate order:
+
+1. `scripts/compute/virtual_machines_export.py`
+2. `scripts/storage/storage_accounts_export.py`
+3. `scripts/network/public_ips_export.py`
+4. `scripts/network/load_balancers_export.py`
+5. `scripts/network/application_gateway_export.py`
+6. `scripts/compute/managed_disks_export.py`
+7. `scripts/resource_groups_export.py`
+
+Rules:
+
+- One exporter per PR unless two are tightly coupled and small.
+- Preserve or improve existing workbook names.
+- Preserve independent script execution.
+- Use Resource Graph KQL internally where it improves cross-subscription
+  coverage and performance.
+- Do not reintroduce a broad 50-sheet Resource Graph workbook.
+
+Validation:
+
+- Import smoke test.
+- Manual run of the touched exporter.
+- Compare workbook sheet intent against the previous exporter.
+
+## What To Avoid
+
+- "Foundation" PRs that also add major feature behavior.
+- Deleting the old exporter tree in the same PR that introduces new helpers.
+- Adding feature sheets to a broad inventory workbook when the feature should be
+  its own exporter.
+- Sidecar HTML reports.
+- Output formats other than `.xlsx`.
+- Live dashboards, monitoring loops, APIs, or services.
+- Dependencies that make Azure Cloud Shell setup heavier.
+- User-facing config switches for cloud partitions that can be detected.
+
+## Review Template For Each PR
+
+Include this checklist in every PR description:
+
+```markdown
+## Architecture Checklist
+
+- [ ] One primary purpose
+- [ ] Exporter remains independently runnable
+- [ ] Main menu only launches subprocesses
+- [ ] Output is `.xlsx`
+- [ ] No HTML/web/API/daemon behavior
+- [ ] Read-only Azure access only
+- [ ] Cloud Shell-friendly dependencies
+- [ ] Public/Gov cloud behavior considered
+- [ ] Errors degrade gracefully where partial export is possible
+- [ ] Tests or smoke checks updated
+```
+
+## Working Agreement
+
+Before opening a PR, verify the branch diff against `origin/dev`:
+
+```bash
+git diff --stat origin/dev...HEAD
+git diff --name-status origin/dev...HEAD
+```
+
+If the diff shows unrelated rewrites, deleted exporter trees, generated files, or
+multiple feature areas, split the work before submitting.

--- a/stratusscan-philosophy.md
+++ b/stratusscan-philosophy.md
@@ -1,0 +1,173 @@
+# StratusScan — Product Philosophy & Boundaries
+
+**Audience:** Claude Code agents working on any StratusScan implementation  
+**Scope:** CSP-agnostic. Applies to `stratusscan-cli` (AWS), `stratusscan-cli-azure` (Azure), and any future cloud provider port.
+
+---
+
+## What StratusScan Is
+
+StratusScan is a terminal-based, menu-driven CLI tool that exports cloud resource inventories to spreadsheets. It targets infrastructure auditors, compliance teams, and cloud administrators who need a complete, human-readable snapshot of what is deployed in a cloud account — with no prior scripting knowledge required.
+
+The tool is deliberately not a monitoring system, a cost management platform, or a security scanner. It is an inventory exporter. It captures the current state of cloud resources and hands the user a workbook they can read, filter, and share without touching a terminal again.
+
+---
+
+## Core Principles
+
+### 1. Terminal Only
+
+StratusScan has no web UI, no daemon, no background service, and no API server. It runs in a terminal, does its work, and exits. The user's interaction surface is the interactive menu or CLI flags — nothing else.
+
+This is intentional. The tool must work in the most constrained environments: a cloud provider's own browser-based shell (AWS CloudShell, Azure Cloud Shell), a locked-down contractor workstation, or a CI/CD pipeline with no GUI. If it requires a browser, a local web server, or persistent state beyond a config file, it does not belong here.
+
+### 2. Menu Driven
+
+The primary interaction model is a numbered, hierarchical terminal menu. Users navigate by typing a number or letter — no prior knowledge of the tool's internals required. Every action a human user might want should be reachable from the main menu within two or three keystrokes.
+
+Menu design rules:
+- Top-level menu launches categories (compute, networking, storage, etc.) or meta-actions (run all, smart scan, configure)
+- Sub-menus list individual exporters within a category
+- Navigation keys are consistent: `[B]` back, `[Q]` quit, `[X]` return to main menu
+- Status panels use box-drawing characters (`╔═╗ / ║ / ╚═╝`) at the top of each screen
+- Section dividers use `═══` with ALL-CAPS labels
+- Status indicators: `✅` ok, `❌` error, `⚠️` warning, `❓` unknown
+- Numbered options for content items `[1][2][3]`; letter keys for navigation
+
+The menu is the face of the tool. Keep it clean, consistent, and predictable.
+
+### 3. Simplicity and Ease of Use
+
+A user who has never run StratusScan before should be able to authenticate to their cloud account, run the tool, and have a populated spreadsheet in their output directory inside five minutes — without reading documentation.
+
+Complexity lives inside the implementation, not the interface. If a design choice makes the menu harder to navigate, the install longer, or the output less readable, it is the wrong choice.
+
+Corollary: do not add features that require the user to understand StratusScan internals. Configuration should be guided (interactive wizard). Errors should be human-readable. Output filenames should be self-describing.
+
+### 4. Bare Minimum Permissions and Dependencies
+
+**Permissions:** StratusScan requires only read-only access to the cloud account. It never writes, modifies, deletes, or provisions resources. Every exporter must fail gracefully when a permission is denied — skip and log, never crash. IAM/RBAC policies for each permission tier live in `policies/` and are maintained alongside the tool.
+
+**Runtime dependencies:** Keep them minimal. The install path is `pip install` (or the CSP equivalent) in a fresh cloud shell session with no extra setup. As of the AWS implementation:
+- Runtime: `boto3` (or CSP SDK equivalent), `pandas`, `openpyxl`, `python-dateutil`, `questionary`
+- No build tools, no compiled extensions, no services that must be running
+
+If a proposed dependency is not available in the CSP's built-in shell environment, reconsider it. If it is available but adds significant install size for marginal value, reconsider it.
+
+**Dev dependencies** (pytest, ruff, black, mypy, moto/equivalent) are installed only via the `[dev]` extras group and never bleed into runtime.
+
+### 5. Capture Everything, Export to Spreadsheets
+
+The goal is completeness. Every service the cloud provider offers that a typical enterprise account might use should have an exporter. Coverage gaps are bugs, not missing features.
+
+Output format is always Excel (`.xlsx`). Reasons:
+- Universally readable without additional tooling
+- Supports multiple sheets per workbook (logical grouping of related resources)
+- Filterable, sortable, and shareable by non-technical stakeholders
+- Printable for physical evidence packages (FedRAMP, SOC 2, etc.)
+
+One service = one exporter script. One exporter = one or more sheets in one workbook. Related services may share a workbook (e.g., a networking workbook with VPCs, subnets, route tables, and security groups), but individual exporters remain independently executable.
+
+---
+
+## Package Structure
+
+Every StratusScan implementation follows this layout:
+
+```
+stratusscan-cli-{csp}/
+├── {csp}scan.py              # Main entry point — menu, navigation, subprocess launcher
+├── configure.py              # Interactive configuration wizard
+├── utils.py                  # Shared library: client factory, logging, Excel helpers, config
+├── pyproject.toml            # Package metadata and dependency declarations
+├── config.json               # Runtime config (auto-created from template on first run)
+├── config-template.json      # Committed template; never contains real credentials
+├── scripts/                  # One .py file per exporter (plus smart_scan/ package)
+│   ├── ec2_export.py         # Example: individual exporter
+│   ├── smart_scan/           # Optional: automated discovery + batch execution package
+│   └── ...
+├── output/                   # All exported .xlsx files land here (gitignored)
+├── logs/                     # Runtime logs (gitignored)
+├── policies/                 # Read-only IAM/RBAC policy documents
+├── reference/                # Static pricing data and lookup tables (JSON)
+└── tests/                    # pytest suite; mirrors scripts/ structure
+```
+
+`{csp}scan.py` is the only orchestrator. It presents the menu, collects user input, and launches exporters as subprocesses. It never calls cloud APIs directly — all cloud interaction is delegated to exporter scripts. This means every exporter is independently runnable from the command line for debugging or CI use.
+
+---
+
+## Naming Conventions
+
+| Thing | Convention | Example |
+|---|---|---|
+| Script filenames | `lowercase_underscored.py` | `ec2_export.py` |
+| Output filenames | `{ACCOUNT-NAME}-{resource-type}-{suffix}-export-{MM.DD.YYYY}.xlsx` | `acme-ec2-instances-export-05.11.2026.xlsx` |
+| Config keys | `lowercase_underscored` | `default_regions` |
+| Directory names | `lowercase-hyphenated` | `smart_scan/`, `session-summaries/` |
+| Date format | `MM.DD.YYYY` | `05.11.2026` |
+| Commit messages | Conventional Commits | `feat(exporters): add lambda export` |
+
+**Script filenames must use underscores, not hyphens.** Hyphens break Python imports. This is non-negotiable.
+
+Account name in output filenames comes from the config's account mapping, never hardcoded. If no mapping exists, fall back to the account/subscription ID.
+
+---
+
+## Pricing Estimates
+
+Where pricing data is available as a static reference (JSON lookup tables keyed by instance type, region, and tier), exporters should include estimated monthly cost columns. This gives the workbook immediate value to cost optimization reviews without requiring any live pricing API calls at runtime.
+
+Rules:
+- Pricing data lives in `reference/` as JSON files, committed to the repo
+- Refresh pricing data approximately quarterly
+- Never call a live pricing API during an export run — static lookups only
+- If pricing data is unavailable for a resource type, omit the column entirely rather than showing zeros or errors
+- Label cost columns clearly: `Estimated Monthly Cost (USD)` with a note that figures are on-demand rates and may differ from actual billing
+
+Pricing data is best-effort. Its absence never blocks an export.
+
+---
+
+## Headless / CLI Flag Operation
+
+Power users, CI pipelines, and automated compliance runs need to drive StratusScan without a human at the keyboard. The tool must support this without requiring workarounds.
+
+**Environment variable layer (always present):**
+- `{CSP}SCAN_AUTO_RUN=1` — suppresses all interactive prompts inside exporters; scripts use defaults or error out cleanly
+- `{CSP}SCAN_REGIONS=us-east-1,us-west-2` — sets target regions non-interactively
+
+**CLI flag layer (Layer 2, built on top of menu):**
+- `--version` — print version and exit
+- `--dry-run` — show what would run without executing
+- `--verbose` — increase log verbosity
+- `--help` — standard usage output
+
+When no flags are passed, the tool falls through to the interactive menu as normal. CLI flags and interactive mode are not mutually exclusive — they serve different audiences on the same binary.
+
+The CLI flag layer is a prerequisite for TUI work. Do not build the TUI before CLI flags exist.
+
+---
+
+## Government Cloud Support
+
+Every StratusScan implementation must support the CSP's government cloud partition from day one — not as an afterthought. Government accounts are primary customers for inventory and compliance tooling.
+
+Implementation rules:
+- Detect the active partition/environment from the authenticated account or region, not from user configuration
+- Inject any required compliance endpoints (FIPS, etc.) automatically — do not expose this as a user-facing setting
+- Guard exporters for services unavailable in government partitions: skip gracefully, log the reason, exit 0
+- Maintain separate `policies/` documents for commercial and government permission sets
+
+---
+
+## What Does Not Belong Here
+
+To keep the scope clear:
+
+- **No resource modification.** StratusScan never writes to the cloud account. PRs that modify, create, or delete cloud resources will be rejected.
+- **No real-time monitoring.** StratusScan is a point-in-time snapshot tool. It does not watch for changes, poll APIs, or maintain persistent connections.
+- **No web UI or API server.** Terminal only. Always.
+- **No proprietary dependencies.** Every dependency must be open source and pip-installable. No vendor SDKs beyond the official CSP SDK.
+- **No credentials in code or config templates.** `config-template.json` is committed; `config.json` is gitignored. Credentials come from the CSP's standard credential chain (environment variables, instance profiles, etc.) — never from config files.
+- **No cloud-provider-specific logic in shared modules.** `utils.py` is the shared library for one CSP implementation. Do not add multi-CSP dispatch logic to it. Each CSP gets its own repo and its own `utils.py`.


### PR DESCRIPTION
## Summary

- Adds the cross-provider StratusScan product philosophy document.
- Adds Codex-facing `AGENTS.md` guidance that points agents at the owner contract before changing code.
- Adds a refactor plan for reshaping the closed PR work into small, architecture-aligned follow-up PRs.

## Why

This locks in the owner feedback from the closed PRs before we resume implementation. The plan makes the next PRs smaller and reviewable: standalone exporters, workbook output, subprocess launcher behavior, and no monolithic Resource Graph workbook as the primary workflow.

## Linked Issue(s)

Related #4
Related #5
Related #6
Related #7

## Validation

How was this verified?

- [ ] Unit tests
- [ ] Integration/end-to-end tests
- [x] Manual verification
- [ ] CI checks passed

Evidence (commands, screenshots, logs, links):

```text
git diff --stat origin/dev...HEAD
AGENTS.md                           |  64 ++++++
docs/owner-aligned-refactor-plan.md | 377 ++++++++++++++++++++++++++++++++++++
stratusscan-philosophy.md           | 173 +++++++++++++++++
3 files changed, 614 insertions(+)
```

## Risk Assessment

- Functional regression: low — documentation only
- Security impact: none — no credentials or runtime behavior changed
- Deployment risk: low — no package or code changes

## Reviewer Checklist

- [ ] Scope matches linked issue intent
- [ ] Acceptance criteria satisfied
- [ ] Test evidence adequate for risk level
- [ ] No sensitive data or secrets introduced

## Architecture Checklist

- [x] One primary purpose
- [x] Exporter remains independently runnable
- [x] Main menu only launches subprocesses
- [x] Output is `.xlsx`
- [x] No HTML/web/API/daemon behavior
- [x] Read-only Azure access only
- [x] Cloud Shell-friendly dependencies
- [x] Public/Gov cloud behavior considered
- [x] Errors degrade gracefully where partial export is possible
- [x] Tests or smoke checks updated — not applicable, docs only
