### PR TITLE
feat(network): flatten NSG rule export

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ cd stratusscan-cli-azure
 
 # Install runtime dependencies
 pip install azure-identity azure-mgmt-resource azure-mgmt-compute azure-mgmt-network \
-    azure-mgmt-storage azure-mgmt-keyvault azure-mgmt-authorization \
+    azure-mgmt-resourcegraph azure-mgmt-storage azure-mgmt-keyvault azure-mgmt-authorization \
     azure-mgmt-containerservice azure-mgmt-web azure-mgmt-sql azure-mgmt-cosmosdb \
     pandas openpyxl python-dateutil questionary
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ cd stratusscan-cli-azure
 
 # Install dependencies
 pip install azure-identity azure-mgmt-resource azure-mgmt-compute azure-mgmt-network \
-    azure-mgmt-storage azure-mgmt-keyvault azure-mgmt-authorization \
+    azure-mgmt-resourcegraph azure-mgmt-storage azure-mgmt-keyvault azure-mgmt-authorization \
     azure-mgmt-containerservice azure-mgmt-web azure-mgmt-sql azure-mgmt-cosmosdb \
     pandas openpyxl python-dateutil questionary
 
@@ -179,7 +179,7 @@ python scripts/security/role_assignments_export.py
 | `managed_disks_export.py` | Managed Disks |
 | `virtual_networks_export.py` | Virtual Networks (VNets) |
 | `subnets_export.py` | Subnets |
-| `network_security_groups_export.py` | Network Security Groups |
+| `network_security_groups_export.py` | Network Security Groups and flattened rules |
 | `public_ips_export.py` | Public IP Addresses |
 | `storage_accounts_export.py` | Storage Accounts |
 | `key_vault_export.py` | Key Vault |
@@ -240,7 +240,7 @@ A purpose-built read-only custom role definition will be provided in `policies/`
 **Missing dependencies**
 ```bash
 pip install azure-identity azure-mgmt-resource azure-mgmt-compute azure-mgmt-network \
-    azure-mgmt-storage azure-mgmt-keyvault azure-mgmt-authorization \
+    azure-mgmt-resourcegraph azure-mgmt-storage azure-mgmt-keyvault azure-mgmt-authorization \
     azure-mgmt-containerservice azure-mgmt-web azure-mgmt-sql azure-mgmt-cosmosdb \
     pandas openpyxl
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ classifiers = [
 dependencies = [
     "azure-identity>=1.15.0",
     "azure-mgmt-resource>=23.0.0",
+    "azure-mgmt-resourcegraph>=8.0.0",
     "azure-mgmt-compute>=30.0.0",
     "azure-mgmt-network>=25.0.0",
     "azure-mgmt-storage>=21.0.0",

--- a/scripts/network/network_security_groups_export.py
+++ b/scripts/network/network_security_groups_export.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """StratusScanCLI-Azure — Network Security Groups Export"""
 
+import os
 import sys
 from pathlib import Path
 
@@ -11,71 +12,271 @@ except ImportError:
     import utils
 
 import pandas as pd
+from azure.mgmt.resourcegraph.models import QueryRequest, QueryRequestOptions
 
 utils.setup_logging("nsg-export")
 utils.log_script_start("network_security_groups_export.py", "Azure NSG Export")
 
 log = utils.get_logger()
 
+NSG_SUMMARY_COLUMNS = [
+    "Name",
+    "Resource Group",
+    "Location",
+    "Custom Rule Count",
+    "Default Rule Count",
+    "Associated Subnets",
+    "Associated NICs",
+    "Flow Log Count",
+    "Provisioning State",
+    "ID",
+    "Tags",
+]
 
-def collect_nsgs(subscription_id: str) -> list:
-    client = utils.get_azure_client("network", subscription_id)
-    log.info("Listing all NSGs in subscription %s", subscription_id)
-    return list(client.network_security_groups.list_all())
+NSG_RULE_COLUMNS = [
+    "Subscription ID",
+    "Resource Group",
+    "NSG Name",
+    "Location",
+    "Rule Type",
+    "Rule Name",
+    "Priority",
+    "Direction",
+    "Access",
+    "Protocol",
+    "Source Address Prefix",
+    "Source Address Prefixes",
+    "Source Port Range",
+    "Source Port Ranges",
+    "Destination Address Prefix",
+    "Destination Address Prefixes",
+    "Destination Port Range",
+    "Destination Port Ranges",
+    "Description",
+    "Source Application Security Groups",
+    "Destination Application Security Groups",
+    "ID",
+]
+
+NSG_SUMMARY_QUERY = """
+Resources
+| where type =~ 'microsoft.network/networksecuritygroups'
+| project
+    name,
+    resourceGroup,
+    location,
+    customRuleCount=array_length(properties.securityRules),
+    defaultRuleCount=array_length(properties.defaultSecurityRules),
+    associatedSubnetCount=array_length(properties.subnets),
+    associatedNicCount=array_length(properties.networkInterfaces),
+    flowLogCount=array_length(properties.flowLogs),
+    provisioningState=tostring(properties.provisioningState),
+    id,
+    tags=tostring(tags)
+"""
+
+NSG_RULES_QUERY = """
+Resources
+| where type =~ 'microsoft.network/networksecuritygroups'
+| mv-expand rule = properties.securityRules
+| extend ruleType = 'Custom'
+| project
+    subscriptionId,
+    resourceGroup,
+    nsgName=name,
+    location,
+    ruleType,
+    ruleName=tostring(rule.name),
+    priority=toint(rule.properties.priority),
+    direction=tostring(rule.properties.direction),
+    access=tostring(rule.properties.access),
+    protocol=tostring(rule.properties.protocol),
+    sourceAddressPrefix=tostring(rule.properties.sourceAddressPrefix),
+    sourceAddressPrefixes=tostring(rule.properties.sourceAddressPrefixes),
+    sourcePortRange=tostring(rule.properties.sourcePortRange),
+    sourcePortRanges=tostring(rule.properties.sourcePortRanges),
+    destinationAddressPrefix=tostring(rule.properties.destinationAddressPrefix),
+    destinationAddressPrefixes=tostring(rule.properties.destinationAddressPrefixes),
+    destinationPortRange=tostring(rule.properties.destinationPortRange),
+    destinationPortRanges=tostring(rule.properties.destinationPortRanges),
+    description=tostring(rule.properties.description),
+    sourceAppSecGroups=tostring(rule.properties.sourceApplicationSecurityGroups),
+    destinationAppSecGroups=tostring(rule.properties.destinationApplicationSecurityGroups),
+    id=strcat(id, '/securityRules/', tostring(rule.name))
+| union (
+    Resources
+    | where type =~ 'microsoft.network/networksecuritygroups'
+    | mv-expand rule = properties.defaultSecurityRules
+    | extend ruleType = 'Default'
+    | project
+        subscriptionId,
+        resourceGroup,
+        nsgName=name,
+        location,
+        ruleType,
+        ruleName=tostring(rule.name),
+        priority=toint(rule.properties.priority),
+        direction=tostring(rule.properties.direction),
+        access=tostring(rule.properties.access),
+        protocol=tostring(rule.properties.protocol),
+        sourceAddressPrefix=tostring(rule.properties.sourceAddressPrefix),
+        sourceAddressPrefixes=tostring(rule.properties.sourceAddressPrefixes),
+        sourcePortRange=tostring(rule.properties.sourcePortRange),
+        sourcePortRanges=tostring(rule.properties.sourcePortRanges),
+        destinationAddressPrefix=tostring(rule.properties.destinationAddressPrefix),
+        destinationAddressPrefixes=tostring(rule.properties.destinationAddressPrefixes),
+        destinationPortRange=tostring(rule.properties.destinationPortRange),
+        destinationPortRanges=tostring(rule.properties.destinationPortRanges),
+        description=tostring(rule.properties.description),
+        sourceAppSecGroups=tostring(rule.properties.sourceApplicationSecurityGroups),
+        destinationAppSecGroups=tostring(rule.properties.destinationApplicationSecurityGroups),
+        id=strcat(id, '/securityRules/', tostring(rule.name))
+)
+| order by nsgName asc, ruleType asc, priority asc
+"""
 
 
-def main(subscription_id: str, subscription_name: str) -> None:
+def _query_resource_graph(subscription_id: str, query: str) -> list:
+    client = utils.get_azure_client("resourcegraph")
+    rows = []
+    skip_token = None
+
+    while True:
+        request = QueryRequest(
+            subscriptions=[subscription_id],
+            query=query,
+            options=QueryRequestOptions(
+                result_format="objectArray",
+                skip_token=skip_token,
+                top=1000,
+            ),
+        )
+        response = client.resources(request)
+        rows.extend(response.data or [])
+        skip_token = response.skip_token
+        if not skip_token:
+            return rows
+
+
+def _summary_dataframe(summary: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(summary, columns=["Pull", "Rows", "Status", "Error"])
+
+
+def collect_nsg_workbook(subscription_id: str) -> tuple[dict, int, int]:
+    summary = []
+
+    try:
+        log.info("Querying NSG inventory via Resource Graph for %s", subscription_id)
+        nsg_rows = _query_resource_graph(subscription_id, NSG_SUMMARY_QUERY)
+        nsg_df = pd.DataFrame(
+            [
+                {
+                    "Name": row.get("name", ""),
+                    "Resource Group": row.get("resourceGroup", ""),
+                    "Location": row.get("location", ""),
+                    "Custom Rule Count": row.get("customRuleCount", 0),
+                    "Default Rule Count": row.get("defaultRuleCount", 0),
+                    "Associated Subnets": row.get("associatedSubnetCount", 0),
+                    "Associated NICs": row.get("associatedNicCount", 0),
+                    "Flow Log Count": row.get("flowLogCount", 0),
+                    "Provisioning State": row.get("provisioningState", ""),
+                    "ID": row.get("id", ""),
+                    "Tags": row.get("tags", ""),
+                }
+                for row in nsg_rows
+            ],
+            columns=NSG_SUMMARY_COLUMNS,
+        )
+        summary.append(
+            {"Pull": "Network Security Groups", "Rows": len(nsg_df), "Status": "OK", "Error": ""}
+        )
+    except Exception as exc:
+        log.error("NSG inventory query failed: %s", exc)
+        nsg_df = pd.DataFrame(columns=NSG_SUMMARY_COLUMNS)
+        summary.append(
+            {
+                "Pull": "Network Security Groups",
+                "Rows": 0,
+                "Status": "ERROR",
+                "Error": str(exc),
+            }
+        )
+
+    try:
+        log.info("Querying flattened NSG rules via Resource Graph for %s", subscription_id)
+        rule_rows = _query_resource_graph(subscription_id, NSG_RULES_QUERY)
+        rules_df = pd.DataFrame(
+            [
+                {
+                    "Subscription ID": row.get("subscriptionId", ""),
+                    "Resource Group": row.get("resourceGroup", ""),
+                    "NSG Name": row.get("nsgName", ""),
+                    "Location": row.get("location", ""),
+                    "Rule Type": row.get("ruleType", ""),
+                    "Rule Name": row.get("ruleName", ""),
+                    "Priority": row.get("priority", ""),
+                    "Direction": row.get("direction", ""),
+                    "Access": row.get("access", ""),
+                    "Protocol": row.get("protocol", ""),
+                    "Source Address Prefix": row.get("sourceAddressPrefix", ""),
+                    "Source Address Prefixes": row.get("sourceAddressPrefixes", ""),
+                    "Source Port Range": row.get("sourcePortRange", ""),
+                    "Source Port Ranges": row.get("sourcePortRanges", ""),
+                    "Destination Address Prefix": row.get("destinationAddressPrefix", ""),
+                    "Destination Address Prefixes": row.get("destinationAddressPrefixes", ""),
+                    "Destination Port Range": row.get("destinationPortRange", ""),
+                    "Destination Port Ranges": row.get("destinationPortRanges", ""),
+                    "Description": row.get("description", ""),
+                    "Source Application Security Groups": row.get("sourceAppSecGroups", ""),
+                    "Destination Application Security Groups": row.get(
+                        "destinationAppSecGroups", ""
+                    ),
+                    "ID": row.get("id", ""),
+                }
+                for row in rule_rows
+            ],
+            columns=NSG_RULE_COLUMNS,
+        )
+        summary.append({"Pull": "NSG Rules", "Rows": len(rules_df), "Status": "OK", "Error": ""})
+    except Exception as exc:
+        log.error("NSG rules query failed: %s", exc)
+        rules_df = pd.DataFrame(columns=NSG_RULE_COLUMNS)
+        summary.append({"Pull": "NSG Rules", "Rows": 0, "Status": "ERROR", "Error": str(exc)})
+
+    sheets = {
+        "Summary": _summary_dataframe(summary),
+        "Network Security Groups": nsg_df,
+        "NSG Rules": rules_df,
+    }
+    error_count = sum(1 for row in summary if row["Status"] == "ERROR")
+    return sheets, len(nsg_df), error_count
+
+
+def main(subscription_id: str, subscription_name: str) -> int:
     environment = utils.detect_environment()
     if not utils.is_service_available_in_environment("network", environment):
-        sys.exit(0)
+        return 0
 
-    nsgs = collect_nsgs(subscription_id)
-    if not nsgs:
-        print("No network security groups found.")
-        return
+    sheets, nsg_count, error_count = collect_nsg_workbook(subscription_id)
 
-    rows = []
-    for nsg in nsgs:
-        rg = nsg.id.split("/resourceGroups/")[1].split("/")[0] if nsg.id else ""
-        tags = nsg.tags or {}
-        inbound = len(nsg.security_rules or [])
-        default_inbound = len(nsg.default_security_rules or [])
-        # Count rules by direction
-        inbound_rules = sum(
-            1 for r in (nsg.security_rules or [])
-            if r.direction and str(r.direction).lower() == "inbound"
-        )
-        outbound_rules = sum(
-            1 for r in (nsg.security_rules or [])
-            if r.direction and str(r.direction).lower() == "outbound"
-        )
-        associated_subnets = len(nsg.subnets or [])
-        associated_nics = len(nsg.network_interfaces or [])
-        rows.append({
-            "Name": nsg.name,
-            "Resource Group": rg,
-            "Location": nsg.location,
-            "Custom Inbound Rules": inbound_rules,
-            "Custom Outbound Rules": outbound_rules,
-            "Default Rules": default_inbound,
-            "Associated Subnets": associated_subnets,
-            "Associated NICs": associated_nics,
-            "Provisioning State": nsg.provisioning_state or "",
-            "Tags": "; ".join(f"{k}={v}" for k, v in tags.items()),
-        })
-
-    df = pd.DataFrame(rows)
     filename = utils.create_export_filename(subscription_name, "network-security-groups", "all")
-    utils.save_dataframe_to_excel(df, filename, sheet_name="NSGs")
-    print(f"Exported {len(rows)} NSG(s) → {filename}")
-    log.info("Export complete: %d NSGs", len(rows))
+    utils.save_multiple_dataframes_to_excel(sheets, filename)
+    if error_count:
+        print(f"Exported NSG workbook with {error_count} error(s) -> {filename}")
+        return 1
+
+    print(f"Exported {nsg_count} network security group(s) -> {filename}")
+    log.info("Export complete: %d NSGs", nsg_count)
+    return 0
 
 
 if __name__ == "__main__":
     cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
+    sub_id = os.environ.get("AZURESCAN_SUBSCRIPTION_ID", "") or cfg.get(
+        "default_subscription_id", ""
+    )
     sub_name = utils.get_subscription_name(sub_id)
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)
-    main(sub_id, sub_name)
+    sys.exit(main(sub_id, sub_name))

--- a/tests/test_network_security_groups_export.py
+++ b/tests/test_network_security_groups_export.py
@@ -1,0 +1,53 @@
+from scripts.network import network_security_groups_export as nsg_export
+
+
+def test_collect_nsg_workbook_builds_summary_and_rule_sheets(monkeypatch):
+    def fake_query(subscription_id, query):
+        assert subscription_id == "sub-123"
+        if query == nsg_export.NSG_SUMMARY_QUERY:
+            return [
+                {
+                    "name": "nsg-prod",
+                    "resourceGroup": "rg-network",
+                    "location": "eastus",
+                    "customRuleCount": 1,
+                    "defaultRuleCount": 3,
+                    "associatedSubnetCount": 2,
+                    "associatedNicCount": 1,
+                    "flowLogCount": 0,
+                    "provisioningState": "Succeeded",
+                    "id": "/subscriptions/sub-123/resourceGroups/rg-network/providers/Microsoft.Network/networkSecurityGroups/nsg-prod",
+                    "tags": '{"env":"prod"}',
+                }
+            ]
+        if query == nsg_export.NSG_RULES_QUERY:
+            return [
+                {
+                    "subscriptionId": "sub-123",
+                    "resourceGroup": "rg-network",
+                    "nsgName": "nsg-prod",
+                    "location": "eastus",
+                    "ruleType": "Custom",
+                    "ruleName": "AllowHttps",
+                    "priority": 100,
+                    "direction": "Inbound",
+                    "access": "Allow",
+                    "protocol": "Tcp",
+                    "sourceAddressPrefix": "Internet",
+                    "destinationPortRange": "443",
+                    "id": "/rules/AllowHttps",
+                }
+            ]
+        raise AssertionError("unexpected query")
+
+    monkeypatch.setattr(nsg_export, "_query_resource_graph", fake_query)
+
+    sheets, nsg_count, error_count = nsg_export.collect_nsg_workbook("sub-123")
+
+    assert list(sheets) == ["Summary", "Network Security Groups", "NSG Rules"]
+    assert nsg_count == 1
+    assert error_count == 0
+    assert sheets["Summary"]["Status"].tolist() == ["OK", "OK"]
+    assert sheets["Network Security Groups"].iloc[0]["Name"] == "nsg-prod"
+    assert sheets["Network Security Groups"].columns[-1] == "Tags"
+    assert sheets["NSG Rules"].iloc[0]["Rule Name"] == "AllowHttps"

--- a/utils.py
+++ b/utils.py
@@ -359,6 +359,7 @@ def _get_credential():
 _CLIENT_MAP: Dict[str, tuple] = {
     "subscription": ("azure.mgmt.resource", "SubscriptionClient", False),
     "resource": ("azure.mgmt.resource", "ResourceManagementClient", True),
+    "resourcegraph": ("azure.mgmt.resourcegraph", "ResourceGraphClient", False),
     "compute": ("azure.mgmt.compute", "ComputeManagementClient", True),
     "network": ("azure.mgmt.network", "NetworkManagementClient", True),
     "storage": ("azure.mgmt.storage", "StorageManagementClient", True),
@@ -410,6 +411,8 @@ def get_azure_client(service_name: str, subscription_id: Optional[str] = None) -
     kwargs: Dict[str, Any] = {}
     if environment == "government":
         kwargs["base_url"] = _GOV_BASE_URL
+        if key == "resourcegraph":
+            kwargs["credential_scopes"] = [f"{_GOV_BASE_URL}/.default"]
 
     if needs_sub:
         return cls(cred, subscription_id, **kwargs)


### PR DESCRIPTION
## Summary

- Updates the existing standalone `network_security_groups_export.py` exporter to use Azure Resource Graph internally.
- Adds a dedicated `NSG Rules` sheet that flattens custom and default NSG rules into one row per rule.
- Keeps the existing targeted exporter/workbook shape: this remains independently runnable and produces a Network Security Groups `.xlsx` workbook.
- Adds the official `azure-mgmt-resourcegraph` dependency and a minimal `utils.get_azure_client("resourcegraph")` mapping, including US Gov ARM scope handling.
- Updates install docs and adds a unit test for workbook construction.

## Why

This follows the owner feedback from #5: flattened NSG rules are useful for auditors, but they belong in the standalone NSG exporter rather than as a sheet in a monolithic Resource Graph workbook.

## Linked Issue(s)

Related #5

## Validation

How was this verified?

- [x] Unit tests
- [ ] Integration/end-to-end tests
- [x] Manual verification
- [ ] CI checks passed

Evidence (commands, screenshots, logs, links):

```text
.venv/bin/python -m py_compile utils.py scripts/network/network_security_groups_export.py
.venv/bin/python -m ruff check scripts/network/network_security_groups_export.py tests/test_network_security_groups_export.py
.venv/bin/python -m black --check scripts/network/network_security_groups_export.py tests/test_network_security_groups_export.py
.venv/bin/python -m pytest tests/test_network_security_groups_export.py -q

1 passed
```

Azure live-run note: local Azure CLI is installed but not authenticated (`az account show` requests `az login`), so this PR is validated with compile/import/lint/unit coverage only.

## Risk Assessment

- Functional regression: low — change is scoped to the existing NSG exporter plus the Resource Graph client dependency/mapping
- Security impact: none — read-only Resource Graph queries only
- Deployment risk: low — adds one official Azure SDK package that is pip-installable in Cloud Shell

## Reviewer Checklist

- [ ] Scope matches linked issue intent
- [ ] Acceptance criteria satisfied
- [ ] Test evidence adequate for risk level
- [ ] No sensitive data or secrets introduced

## Architecture Checklist

- [x] One primary purpose
- [x] Exporter remains independently runnable
- [x] Main menu only launches subprocesses
- [x] Output is `.xlsx`
- [x] No HTML/web/API/daemon behavior
- [x] Read-only Azure access only
- [x] Cloud Shell-friendly dependencies
- [x] Public/Gov cloud behavior considered
- [x] Errors degrade gracefully where partial export is possible
- [x] Tests or smoke checks updated
