### PR TITLE
feat(compute): add orphaned disk flag to managed disks export

### DIFF
--- a/scripts/compute/managed_disks_export.py
+++ b/scripts/compute/managed_disks_export.py
@@ -67,6 +67,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
             "State": str(disk.disk_state) if disk.disk_state else "",
             "Encryption": _encryption_type(disk),
             "Attached VM": _attached_vm(disk),
+            "Orphaned": "Yes" if not disk.managed_by else "No",
             "Zones": ", ".join(disk.zones) if disk.zones else "",
             "Tags": "; ".join(f"{k}={v}" for k, v in tags.items()),
         })


### PR DESCRIPTION
## Summary

- Adds an `Orphaned` column (`Yes`/`No`) to the managed disks export based on whether `managedBy` is null
- Existing `Attached VM` column already shows the VM name — the new column makes filtering/sorting for unattached disks trivial in Excel

Closes #10

## Context

FCC Azure audit gap analysis §1.7 needs orphaned disk identification across all subscriptions to quantify storage cost waste.

## Test plan

- [ ] Run `managed_disks_export.py` against a subscription with both attached and unattached disks
- [ ] Verify `Orphaned` = `Yes` for disks with blank `Attached VM`, `No` otherwise
- [ ] Verify xlsx opens cleanly and column is filterable

🤖 Generated with [Claude Code](https://claude.com/claude-code)