### PR TITLE
feat(governance): add management groups exporter

### DIFF
--- a/azurescan.py
+++ b/azurescan.py
@@ -63,6 +63,10 @@ TIER2_EXPORTERS = [
     ("VNet Peerings",                  "network/vnet_peerings_export.py"),
 ]
 
+GOVERNANCE_EXPORTERS = [
+    ("Management Groups",              "governance/management_groups_export.py"),
+]
+
 
 # ---------------------------------------------------------------------------
 # Subscription resolution
@@ -189,14 +193,36 @@ def menu_tier2(sub_id: str, sub_name: str) -> None:
             _run_exporter(path, sub_id, sub_name)
 
 
+def menu_governance(sub_id: str, sub_name: str) -> None:
+    while True:
+        options = [label for label, _ in GOVERNANCE_EXPORTERS] + ["Run All Governance Exporters"]
+        choice = utils.prompt_menu(
+            f"GOVERNANCE EXPORTERS  ({sub_name})",
+            options,
+            allow_back=True,
+            allow_exit=True,
+        )
+        if choice == "back":
+            return
+        if choice == "exit":
+            sys.exit(0)
+        if choice == len(options):
+            _run_all_exporters(GOVERNANCE_EXPORTERS, sub_id, sub_name)
+        else:
+            label, path = GOVERNANCE_EXPORTERS[choice - 1]
+            print(f"\nRunning: {label}")
+            _run_exporter(path, sub_id, sub_name)
+
+
 def menu_main(sub_id: str, sub_name: str) -> None:
     _print_banner()
     while True:
         options = [
-            "Tier 1 Exporters  (Core infrastructure: VMs, VNets, Storage, Key Vault, RBAC…)",
-            "Tier 2 Exporters  (Workloads: AKS, App Service, SQL, Cosmos DB, Gateways…)",
-            "Run All Exporters  (Tier 1 + Tier 2)",
-            "Configure          (subscription selection, environment settings)",
+            "Tier 1 Exporters   (Core infrastructure: VMs, VNets, Storage, Key Vault, RBAC…)",
+            "Tier 2 Exporters   (Workloads: AKS, App Service, SQL, Cosmos DB, Gateways…)",
+            "Governance          (Management Groups, Policy, Defender, Advisor…)",
+            "Run All Exporters   (Tier 1 + Tier 2 + Governance)",
+            "Configure           (subscription selection, environment settings)",
         ]
         choice = utils.prompt_menu(
             "AZURESCAN MAIN MENU",
@@ -212,8 +238,10 @@ def menu_main(sub_id: str, sub_name: str) -> None:
         elif choice == 2:
             menu_tier2(sub_id, sub_name)
         elif choice == 3:
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS, sub_id, sub_name)
+            menu_governance(sub_id, sub_name)
         elif choice == 4:
+            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS, sub_id, sub_name)
+        elif choice == 5:
             subprocess.run([sys.executable, str(Path(__file__).parent / "configure.py")])
             # Reload config after configure
             import importlib
@@ -233,7 +261,7 @@ def main() -> None:
         for sid in all_subs:
             sname = utils.get_subscription_name(sid)
             print(f"\nAuto-run: scanning subscription {sname} ({sid})")
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS, sid, sname)
+            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS, sid, sname)
         return
 
     menu_main(sub_id, sub_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "azure-mgmt-web>=7.0.0",
     "azure-mgmt-sql>=3.0.0",
     "azure-mgmt-cosmosdb>=9.0.0",
+    "azure-mgmt-managementgroups>=1.0.0",
     "pandas>=2.0.0",
     "openpyxl>=3.1.0",
     "python-dateutil>=2.8.2",

--- a/scripts/governance/management_groups_export.py
+++ b/scripts/governance/management_groups_export.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Management Groups Export"""
+
+import sys
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("management-groups-export")
+utils.log_script_start("management_groups_export.py", "Management Groups Export")
+
+log = utils.get_logger()
+
+
+def _count_subscriptions(mg) -> int:
+    if not hasattr(mg, "children") or not mg.children:
+        return 0
+    return sum(
+        1 for child in mg.children
+        if child.type and child.type.endswith("/subscriptions")
+    )
+
+
+def _get_parent_info(mg) -> tuple:
+    if not hasattr(mg, "details") or not mg.details:
+        return "", ""
+    parent = getattr(mg.details, "parent", None)
+    if not parent:
+        return "", ""
+    parent_id = getattr(parent, "id", "") or ""
+    parent_name = getattr(parent, "display_name", "") or getattr(parent, "name", "") or ""
+    if not parent_name and parent_id:
+        parent_name = parent_id.split("/")[-1]
+    return parent_id, parent_name
+
+
+def collect_management_groups() -> list:
+    client = utils.get_azure_client("managementgroups")
+    log.info("Listing management groups")
+
+    groups = list(client.management_groups.list())
+    log.info("Found %d management group(s), fetching details", len(groups))
+
+    rows = []
+    for mg in groups:
+        mg_id = mg.name or ""
+        try:
+            detail = client.management_groups.get(mg_id, expand="children")
+        except Exception as e:
+            log.warning("Failed to get details for management group %s: %s", mg_id, e)
+            detail = mg
+
+        parent_id, parent_name = _get_parent_info(detail)
+        sub_count = _count_subscriptions(detail)
+
+        rows.append({
+            "Management Group Name": getattr(detail, "display_name", "") or mg_id,
+            "Display Name": getattr(detail, "display_name", "") or "",
+            "ID": mg_id,
+            "Parent ID": parent_id,
+            "Parent Name": parent_name,
+            "Subscription Count": sub_count,
+        })
+
+    return rows
+
+
+def main(subscription_name: str) -> None:
+    rows = collect_management_groups()
+
+    if not rows:
+        print("No management groups found.")
+        return
+
+    df = pd.DataFrame(rows)
+    filename = utils.create_export_filename(subscription_name, "management-groups", "all")
+    utils.save_dataframe_to_excel(df, filename)
+    print(f"Exported {len(rows)} management group(s) → {filename}")
+    log.info("Export complete: %d management groups", len(rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_name)

--- a/utils.py
+++ b/utils.py
@@ -368,6 +368,7 @@ _CLIENT_MAP: Dict[str, tuple] = {
     "web": ("azure.mgmt.web", "WebSiteManagementClient", True),
     "sql": ("azure.mgmt.sql", "SqlManagementClient", True),
     "cosmosdb": ("azure.mgmt.cosmosdb", "CosmosDBManagementClient", True),
+    "managementgroups": ("azure.mgmt.managementgroups", "ManagementGroupsAPI", False),
 }
 
 # Government cloud base URL override


### PR DESCRIPTION
## Summary
- New exporter `scripts/governance/management_groups_export.py` — exports the full management group hierarchy with parent/child relationships and subscription counts
- Adds `managementgroups` service to `_CLIENT_MAP` in utils.py (tenant-level, `needs_sub=False`)
- Adds `azure-mgmt-managementgroups>=1.0.0` dependency to pyproject.toml
- Introduces Governance menu tier in azurescan.py main menu (same structure PR #22 adds — will merge cleanly with whichever lands first)

## Fields Exported
| Column | Source |
|---|---|
| Management Group Name | `display_name` or `name` |
| Display Name | `display_name` |
| ID | `name` (the MG identifier) |
| Parent ID | `details.parent.id` |
| Parent Name | `details.parent.display_name` |
| Subscription Count | Count of direct children with type `subscriptions` |

## Test plan
- [ ] Run standalone: `python scripts/governance/management_groups_export.py`
- [ ] Run from main menu → Governance → Management Groups
- [ ] Run in CI mode: `AZURESCAN_AUTO_RUN=1 AZURESCAN_SUBSCRIPTIONS=<id> python azurescan.py`
- [ ] Verify xlsx output in `output/` with correct columns and hierarchy data

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)