### PR TITLE
feat(security): add Defender for Cloud secure score exporter

### DIFF
--- a/azurescan.py
+++ b/azurescan.py
@@ -63,6 +63,10 @@ TIER2_EXPORTERS = [
     ("VNet Peerings",                  "network/vnet_peerings_export.py"),
 ]
 
+GOVERNANCE_EXPORTERS = [
+    ("Defender Secure Scores & Plans", "security/defender_scores_export.py"),
+]
+
 
 # ---------------------------------------------------------------------------
 # Subscription resolution
@@ -189,14 +193,36 @@ def menu_tier2(sub_id: str, sub_name: str) -> None:
             _run_exporter(path, sub_id, sub_name)
 
 
+def menu_governance(sub_id: str, sub_name: str) -> None:
+    while True:
+        options = [label for label, _ in GOVERNANCE_EXPORTERS] + ["Run All Governance Exporters"]
+        choice = utils.prompt_menu(
+            f"GOVERNANCE EXPORTERS  ({sub_name})",
+            options,
+            allow_back=True,
+            allow_exit=True,
+        )
+        if choice == "back":
+            return
+        if choice == "exit":
+            sys.exit(0)
+        if choice == len(options):
+            _run_all_exporters(GOVERNANCE_EXPORTERS, sub_id, sub_name)
+        else:
+            label, path = GOVERNANCE_EXPORTERS[choice - 1]
+            print(f"\nRunning: {label}")
+            _run_exporter(path, sub_id, sub_name)
+
+
 def menu_main(sub_id: str, sub_name: str) -> None:
     _print_banner()
     while True:
         options = [
-            "Tier 1 Exporters  (Core infrastructure: VMs, VNets, Storage, Key Vault, RBAC…)",
-            "Tier 2 Exporters  (Workloads: AKS, App Service, SQL, Cosmos DB, Gateways…)",
-            "Run All Exporters  (Tier 1 + Tier 2)",
-            "Configure          (subscription selection, environment settings)",
+            "Tier 1 Exporters   (Core infrastructure: VMs, VNets, Storage, Key Vault, RBAC…)",
+            "Tier 2 Exporters   (Workloads: AKS, App Service, SQL, Cosmos DB, Gateways…)",
+            "Governance          (Defender, Policy, Management Groups, Advisor…)",
+            "Run All Exporters   (Tier 1 + Tier 2 + Governance)",
+            "Configure           (subscription selection, environment settings)",
         ]
         choice = utils.prompt_menu(
             "AZURESCAN MAIN MENU",
@@ -212,8 +238,10 @@ def menu_main(sub_id: str, sub_name: str) -> None:
         elif choice == 2:
             menu_tier2(sub_id, sub_name)
         elif choice == 3:
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS, sub_id, sub_name)
+            menu_governance(sub_id, sub_name)
         elif choice == 4:
+            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS, sub_id, sub_name)
+        elif choice == 5:
             subprocess.run([sys.executable, str(Path(__file__).parent / "configure.py")])
             # Reload config after configure
             import importlib
@@ -233,7 +261,7 @@ def main() -> None:
         for sid in all_subs:
             sname = utils.get_subscription_name(sid)
             print(f"\nAuto-run: scanning subscription {sname} ({sid})")
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS, sid, sname)
+            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS, sid, sname)
         return
 
     menu_main(sub_id, sub_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "azure-mgmt-web>=7.0.0",
     "azure-mgmt-sql>=3.0.0",
     "azure-mgmt-cosmosdb>=9.0.0",
+    "azure-mgmt-security>=5.0.0",
     "pandas>=2.0.0",
     "openpyxl>=3.1.0",
     "python-dateutil>=2.8.2",

--- a/scripts/security/defender_scores_export.py
+++ b/scripts/security/defender_scores_export.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Defender for Cloud Secure Score & Plans Export"""
+
+import sys
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("defender-scores-export")
+utils.log_script_start("defender_scores_export.py", "Defender Secure Score & Plans Export")
+
+log = utils.get_logger()
+
+
+def collect_secure_scores(subscription_id: str) -> list:
+    client = utils.get_azure_client("security", subscription_id)
+    log.info("Listing secure scores for subscription %s", subscription_id)
+
+    rows = []
+    try:
+        for score in client.secure_scores.list():
+            current = 0.0
+            max_score = 0.0
+            percentage = 0.0
+            weight = 0
+
+            if hasattr(score, "score") and score.score:
+                current = getattr(score.score, "current", 0.0) or 0.0
+                max_score = getattr(score.score, "max", 0.0) or 0.0
+                percentage = getattr(score.score, "percentage", 0.0) or 0.0
+
+            if hasattr(score, "weight") and score.weight is not None:
+                weight = score.weight
+
+            rows.append({
+                "Score Name": getattr(score, "display_name", "") or getattr(score, "name", "") or "",
+                "Current Score": current,
+                "Max Score": max_score,
+                "Percentage": round(percentage * 100, 2) if percentage <= 1.0 else round(percentage, 2),
+                "Weight": weight,
+            })
+    except Exception as e:
+        log.warning("Failed to list secure scores: %s", e)
+
+    return rows
+
+
+def collect_defender_plans(subscription_id: str) -> list:
+    client = utils.get_azure_client("security", subscription_id)
+    log.info("Listing Defender plans (pricings) for subscription %s", subscription_id)
+
+    rows = []
+    try:
+        result = client.pricings.list()
+        pricings = result.value if hasattr(result, "value") else list(result)
+        for p in pricings:
+            rows.append({
+                "Plan Name": getattr(p, "name", "") or "",
+                "Pricing Tier": getattr(p, "pricing_tier", "") or "",
+                "Free Trial Remaining": getattr(p, "free_trial_remaining_time", "") or "",
+                "Enabled": "Yes" if getattr(p, "pricing_tier", "").lower() == "standard" else "No",
+            })
+    except Exception as e:
+        log.warning("Failed to list Defender plans: %s", e)
+
+    return rows
+
+
+def main(subscription_id: str, subscription_name: str) -> None:
+    environment = utils.detect_environment()
+    if not utils.is_service_available_in_environment("resource", environment):
+        sys.exit(0)
+
+    score_rows = collect_secure_scores(subscription_id)
+    plan_rows = collect_defender_plans(subscription_id)
+
+    if not score_rows and not plan_rows:
+        print("No Defender scores or plans found.")
+        return
+
+    sheets = {}
+    if score_rows:
+        sheets["Secure Scores"] = pd.DataFrame(score_rows)
+    if plan_rows:
+        sheets["Defender Plans"] = pd.DataFrame(plan_rows)
+
+    filename = utils.create_export_filename(subscription_name, "defender-scores", "all")
+    utils.save_multiple_dataframes_to_excel(sheets, filename)
+    print(f"Exported {len(score_rows)} score(s), {len(plan_rows)} plan(s) → {filename}")
+    log.info("Export complete: %d scores, %d plans", len(score_rows), len(plan_rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_id, sub_name)

--- a/utils.py
+++ b/utils.py
@@ -368,6 +368,7 @@ _CLIENT_MAP: Dict[str, tuple] = {
     "web": ("azure.mgmt.web", "WebSiteManagementClient", True),
     "sql": ("azure.mgmt.sql", "SqlManagementClient", True),
     "cosmosdb": ("azure.mgmt.cosmosdb", "CosmosDBManagementClient", True),
+    "security": ("azure.mgmt.security", "SecurityCenter", True),
 }
 
 # Government cloud base URL override


### PR DESCRIPTION
## Summary
- New exporter `scripts/security/defender_scores_export.py` — two-sheet xlsx with Secure Scores and Defender Plans
- Adds `security` (SecurityCenter) service to `_CLIENT_MAP` in utils.py
- Adds `azure-mgmt-security>=5.0.0` dependency to pyproject.toml
- Introduces Governance menu tier (merges cleanly with #22 and #23 which add their own entries)

## Sheets Exported

**Secure Scores:** Score Name, Current Score, Max Score, Percentage, Weight

**Defender Plans:** Plan Name, Pricing Tier, Free Trial Remaining, Enabled

## Test plan
- [ ] Run standalone: `python scripts/security/defender_scores_export.py`
- [ ] Run from main menu → Governance → Defender Secure Scores & Plans
- [ ] Verify xlsx has both sheets with correct columns
- [ ] Run in CI mode: `AZURESCAN_AUTO_RUN=1 AZURESCAN_SUBSCRIPTIONS=<id> python azurescan.py`

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)