### PR TITLE
feat(security): add Defender assessments exporter

### DIFF
--- a/azurescan.py
+++ b/azurescan.py
@@ -63,6 +63,10 @@ TIER2_EXPORTERS = [
     ("VNet Peerings",                  "network/vnet_peerings_export.py"),
 ]
 
+GOVERNANCE_EXPORTERS = [
+    ("Defender Assessments",           "security/defender_assessments_export.py"),
+]
+
 
 # ---------------------------------------------------------------------------
 # Subscription resolution
@@ -189,14 +193,36 @@ def menu_tier2(sub_id: str, sub_name: str) -> None:
             _run_exporter(path, sub_id, sub_name)
 
 
+def menu_governance(sub_id: str, sub_name: str) -> None:
+    while True:
+        options = [label for label, _ in GOVERNANCE_EXPORTERS] + ["Run All Governance Exporters"]
+        choice = utils.prompt_menu(
+            f"GOVERNANCE EXPORTERS  ({sub_name})",
+            options,
+            allow_back=True,
+            allow_exit=True,
+        )
+        if choice == "back":
+            return
+        if choice == "exit":
+            sys.exit(0)
+        if choice == len(options):
+            _run_all_exporters(GOVERNANCE_EXPORTERS, sub_id, sub_name)
+        else:
+            label, path = GOVERNANCE_EXPORTERS[choice - 1]
+            print(f"\nRunning: {label}")
+            _run_exporter(path, sub_id, sub_name)
+
+
 def menu_main(sub_id: str, sub_name: str) -> None:
     _print_banner()
     while True:
         options = [
-            "Tier 1 Exporters  (Core infrastructure: VMs, VNets, Storage, Key Vault, RBAC…)",
-            "Tier 2 Exporters  (Workloads: AKS, App Service, SQL, Cosmos DB, Gateways…)",
-            "Run All Exporters  (Tier 1 + Tier 2)",
-            "Configure          (subscription selection, environment settings)",
+            "Tier 1 Exporters   (Core infrastructure: VMs, VNets, Storage, Key Vault, RBAC…)",
+            "Tier 2 Exporters   (Workloads: AKS, App Service, SQL, Cosmos DB, Gateways…)",
+            "Governance          (Defender, Policy, Management Groups, Advisor…)",
+            "Run All Exporters   (Tier 1 + Tier 2 + Governance)",
+            "Configure           (subscription selection, environment settings)",
         ]
         choice = utils.prompt_menu(
             "AZURESCAN MAIN MENU",
@@ -212,8 +238,10 @@ def menu_main(sub_id: str, sub_name: str) -> None:
         elif choice == 2:
             menu_tier2(sub_id, sub_name)
         elif choice == 3:
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS, sub_id, sub_name)
+            menu_governance(sub_id, sub_name)
         elif choice == 4:
+            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS, sub_id, sub_name)
+        elif choice == 5:
             subprocess.run([sys.executable, str(Path(__file__).parent / "configure.py")])
             # Reload config after configure
             import importlib
@@ -233,7 +261,7 @@ def main() -> None:
         for sid in all_subs:
             sname = utils.get_subscription_name(sid)
             print(f"\nAuto-run: scanning subscription {sname} ({sid})")
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS, sid, sname)
+            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS, sid, sname)
         return
 
     menu_main(sub_id, sub_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "azure-mgmt-web>=7.0.0",
     "azure-mgmt-sql>=3.0.0",
     "azure-mgmt-cosmosdb>=9.0.0",
+    "azure-mgmt-security>=5.0.0",
     "pandas>=2.0.0",
     "openpyxl>=3.1.0",
     "python-dateutil>=2.8.2",

--- a/scripts/security/defender_assessments_export.py
+++ b/scripts/security/defender_assessments_export.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Defender Security Assessments Export"""
+
+import sys
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("defender-assessments-export")
+utils.log_script_start("defender_assessments_export.py", "Defender Security Assessments Export")
+
+log = utils.get_logger()
+
+
+def _extract_resource_info(resource_details) -> tuple:
+    if not resource_details:
+        return "", "", ""
+    source = getattr(resource_details, "source", None) or resource_details
+    rid = getattr(source, "id", "") or ""
+    parts = rid.split("/") if rid else []
+    rname = parts[-1] if len(parts) > 1 else ""
+    rtype = ""
+    if len(parts) >= 2:
+        rtype = "/".join(parts[-2:]) if not parts[-2].startswith("Microsoft.") else "/".join(parts[-3:-1])
+    return rid, rname, rtype
+
+
+def _status_code(status) -> str:
+    if not status:
+        return ""
+    code = getattr(status, "code", "") or ""
+    return str(code)
+
+
+def collect_assessments(subscription_id: str) -> list:
+    client = utils.get_azure_client("security", subscription_id)
+    log.info("Listing security assessments for subscription %s", subscription_id)
+
+    rows = []
+    try:
+        for a in client.assessments.list(scope=f"/subscriptions/{subscription_id}"):
+            status = getattr(a, "status", None)
+            status_code = _status_code(status)
+
+            metadata = getattr(a, "metadata", None) if hasattr(a, "metadata") else None
+            display_name = ""
+            severity = ""
+            category = ""
+            description = ""
+            remediation = ""
+
+            if metadata:
+                display_name = getattr(metadata, "display_name", "") or ""
+                severity = getattr(metadata, "severity", "") or ""
+                categories = getattr(metadata, "categories", None)
+                if categories:
+                    category = ", ".join(str(c) for c in categories)
+                description = getattr(metadata, "description", "") or ""
+                remediation = getattr(metadata, "remediation_description", "") or ""
+
+            resource_details = getattr(a, "resource_details", None)
+            rid, rname, rtype = _extract_resource_info(resource_details)
+
+            rows.append({
+                "Assessment Name": getattr(a, "name", "") or "",
+                "Display Name": display_name or getattr(a, "display_name", "") or "",
+                "Status": status_code,
+                "Severity": severity,
+                "Category": category,
+                "Resource ID": rid,
+                "Resource Name": rname,
+                "Resource Type": rtype,
+                "Description": description,
+                "Remediation": remediation,
+            })
+    except Exception as e:
+        log.warning("Failed to list assessments: %s", e)
+
+    return rows
+
+
+def main(subscription_id: str, subscription_name: str) -> None:
+    environment = utils.detect_environment()
+    if not utils.is_service_available_in_environment("resource", environment):
+        sys.exit(0)
+
+    rows = collect_assessments(subscription_id)
+
+    if not rows:
+        print("No security assessments found.")
+        return
+
+    df = pd.DataFrame(rows)
+    filename = utils.create_export_filename(subscription_name, "defender-assessments", "all")
+    utils.save_dataframe_to_excel(df, filename)
+    print(f"Exported {len(rows)} assessment(s) → {filename}")
+    log.info("Export complete: %d assessments", len(rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_id, sub_name)

--- a/utils.py
+++ b/utils.py
@@ -368,6 +368,7 @@ _CLIENT_MAP: Dict[str, tuple] = {
     "web": ("azure.mgmt.web", "WebSiteManagementClient", True),
     "sql": ("azure.mgmt.sql", "SqlManagementClient", True),
     "cosmosdb": ("azure.mgmt.cosmosdb", "CosmosDBManagementClient", True),
+    "security": ("azure.mgmt.security", "SecurityCenter", True),
 }
 
 # Government cloud base URL override


### PR DESCRIPTION
## Summary
- New exporter `scripts/security/defender_assessments_export.py` — exports security assessments/recommendations from Defender for Cloud
- Reuses `security` (SecurityCenter) service in `_CLIENT_MAP` (same SDK as #24)
- Adds `azure-mgmt-security>=5.0.0` dependency (overlaps with #24 — merges cleanly)
- Adds Governance menu tier (overlaps with #22–#24 — merges cleanly)

## Fields Exported
| Column | Source |
|---|---|
| Assessment Name | `name` |
| Display Name | `metadata.display_name` |
| Status | `status.code` (Healthy/Unhealthy/NotApplicable) |
| Severity | `metadata.severity` |
| Category | `metadata.categories` |
| Resource ID | `resource_details.source.id` |
| Resource Name | Parsed from resource ID |
| Resource Type | Parsed from resource ID |
| Description | `metadata.description` |
| Remediation | `metadata.remediation_description` |

## Test plan
- [ ] Run standalone: `python scripts/security/defender_assessments_export.py`
- [ ] Run from main menu → Governance → Defender Assessments
- [ ] Verify xlsx with correct columns and status values
- [ ] Run in CI mode: `AZURESCAN_AUTO_RUN=1 AZURESCAN_SUBSCRIPTIONS=<id> python azurescan.py`

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)