### PR TITLE
feat(governance): add Azure Advisor recommendations exporter

### DIFF
--- a/azurescan.py
+++ b/azurescan.py
@@ -63,6 +63,10 @@ TIER2_EXPORTERS = [
     ("VNet Peerings",                  "network/vnet_peerings_export.py"),
 ]
 
+GOVERNANCE_EXPORTERS = [
+    ("Advisor Recommendations",        "governance/advisor_export.py"),
+]
+
 
 # ---------------------------------------------------------------------------
 # Subscription resolution
@@ -189,14 +193,36 @@ def menu_tier2(sub_id: str, sub_name: str) -> None:
             _run_exporter(path, sub_id, sub_name)
 
 
+def menu_governance(sub_id: str, sub_name: str) -> None:
+    while True:
+        options = [label for label, _ in GOVERNANCE_EXPORTERS] + ["Run All Governance Exporters"]
+        choice = utils.prompt_menu(
+            f"GOVERNANCE EXPORTERS  ({sub_name})",
+            options,
+            allow_back=True,
+            allow_exit=True,
+        )
+        if choice == "back":
+            return
+        if choice == "exit":
+            sys.exit(0)
+        if choice == len(options):
+            _run_all_exporters(GOVERNANCE_EXPORTERS, sub_id, sub_name)
+        else:
+            label, path = GOVERNANCE_EXPORTERS[choice - 1]
+            print(f"\nRunning: {label}")
+            _run_exporter(path, sub_id, sub_name)
+
+
 def menu_main(sub_id: str, sub_name: str) -> None:
     _print_banner()
     while True:
         options = [
-            "Tier 1 Exporters  (Core infrastructure: VMs, VNets, Storage, Key Vault, RBAC…)",
-            "Tier 2 Exporters  (Workloads: AKS, App Service, SQL, Cosmos DB, Gateways…)",
-            "Run All Exporters  (Tier 1 + Tier 2)",
-            "Configure          (subscription selection, environment settings)",
+            "Tier 1 Exporters   (Core infrastructure: VMs, VNets, Storage, Key Vault, RBAC…)",
+            "Tier 2 Exporters   (Workloads: AKS, App Service, SQL, Cosmos DB, Gateways…)",
+            "Governance          (Advisor, Defender, Policy, Management Groups…)",
+            "Run All Exporters   (Tier 1 + Tier 2 + Governance)",
+            "Configure           (subscription selection, environment settings)",
         ]
         choice = utils.prompt_menu(
             "AZURESCAN MAIN MENU",
@@ -212,8 +238,10 @@ def menu_main(sub_id: str, sub_name: str) -> None:
         elif choice == 2:
             menu_tier2(sub_id, sub_name)
         elif choice == 3:
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS, sub_id, sub_name)
+            menu_governance(sub_id, sub_name)
         elif choice == 4:
+            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS, sub_id, sub_name)
+        elif choice == 5:
             subprocess.run([sys.executable, str(Path(__file__).parent / "configure.py")])
             # Reload config after configure
             import importlib
@@ -233,7 +261,7 @@ def main() -> None:
         for sid in all_subs:
             sname = utils.get_subscription_name(sid)
             print(f"\nAuto-run: scanning subscription {sname} ({sid})")
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS, sid, sname)
+            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS, sid, sname)
         return
 
     menu_main(sub_id, sub_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "azure-mgmt-web>=7.0.0",
     "azure-mgmt-sql>=3.0.0",
     "azure-mgmt-cosmosdb>=9.0.0",
+    "azure-mgmt-advisor>=9.0.0",
     "pandas>=2.0.0",
     "openpyxl>=3.1.0",
     "python-dateutil>=2.8.2",

--- a/scripts/governance/advisor_export.py
+++ b/scripts/governance/advisor_export.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Azure Advisor Recommendations Export"""
+
+import sys
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("advisor-export")
+utils.log_script_start("advisor_export.py", "Azure Advisor Recommendations Export")
+
+log = utils.get_logger()
+
+
+def _parse_resource_id(resource_id: str) -> tuple:
+    if not resource_id:
+        return "", ""
+    parts = resource_id.split("/")
+    rname = parts[-1] if len(parts) > 1 else ""
+    rtype = ""
+    for i, p in enumerate(parts):
+        if p.lower() == "providers" and i + 2 < len(parts):
+            rtype = "/".join(parts[i + 1 : i + 3])
+            break
+    return rname, rtype
+
+
+def _extract_savings(extended_properties: dict) -> str:
+    if not extended_properties:
+        return ""
+    for key in ("savingsAmount", "annualSavingsAmount", "estimatedAnnualSavings", "savings"):
+        val = extended_properties.get(key)
+        if val is not None:
+            currency = extended_properties.get("savingsCurrency", "USD")
+            return f"{val} {currency}"
+    return ""
+
+
+def collect_recommendations(subscription_id: str) -> list:
+    client = utils.get_azure_client("advisor", subscription_id)
+    log.info("Listing Advisor recommendations for subscription %s", subscription_id)
+
+    rows = []
+    try:
+        for rec in client.recommendations.list():
+            resource_id = getattr(rec, "resource_id", "") or getattr(rec, "impacted_field", "") or ""
+            rname, rtype = _parse_resource_id(resource_id)
+
+            extended = getattr(rec, "extended_properties", None) or {}
+            short_desc = getattr(rec, "short_description", None)
+            problem = ""
+            solution = ""
+            if short_desc:
+                problem = getattr(short_desc, "problem", "") or ""
+                solution = getattr(short_desc, "solution", "") or ""
+
+            last_updated = getattr(rec, "last_updated", "") or ""
+            if hasattr(last_updated, "isoformat"):
+                last_updated = last_updated.isoformat()
+
+            rows.append({
+                "Category": getattr(rec, "category", "") or "",
+                "Impact": getattr(rec, "impact", "") or "",
+                "Resource ID": resource_id,
+                "Resource Name": rname or getattr(rec, "impacted_value", "") or "",
+                "Resource Type": rtype or getattr(rec, "impacted_field", "") or "",
+                "Recommendation": problem,
+                "Solution": solution,
+                "Potential Savings": _extract_savings(extended),
+                "Last Updated": last_updated,
+            })
+    except Exception as e:
+        log.warning("Failed to list Advisor recommendations: %s", e)
+
+    return rows
+
+
+def main(subscription_id: str, subscription_name: str) -> None:
+    environment = utils.detect_environment()
+    if not utils.is_service_available_in_environment("resource", environment):
+        sys.exit(0)
+
+    rows = collect_recommendations(subscription_id)
+
+    if not rows:
+        print("No Advisor recommendations found.")
+        return
+
+    df = pd.DataFrame(rows)
+    filename = utils.create_export_filename(subscription_name, "advisor-recommendations", "all")
+    utils.save_dataframe_to_excel(df, filename)
+    print(f"Exported {len(rows)} recommendation(s) → {filename}")
+    log.info("Export complete: %d recommendations", len(rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_id, sub_name)

--- a/utils.py
+++ b/utils.py
@@ -368,6 +368,7 @@ _CLIENT_MAP: Dict[str, tuple] = {
     "web": ("azure.mgmt.web", "WebSiteManagementClient", True),
     "sql": ("azure.mgmt.sql", "SqlManagementClient", True),
     "cosmosdb": ("azure.mgmt.cosmosdb", "CosmosDBManagementClient", True),
+    "advisor": ("azure.mgmt.advisor", "AdvisorManagementClient", True),
 }
 
 # Government cloud base URL override


### PR DESCRIPTION
## Summary
- New exporter `scripts/governance/advisor_export.py` — exports all Advisor recommendations across all categories
- Adds `advisor` (AdvisorManagementClient) service to `_CLIENT_MAP` in utils.py
- Adds `azure-mgmt-advisor>=9.0.0` dependency to pyproject.toml
- Adds Governance menu tier (merges cleanly with #22–#25)

## Fields Exported
| Column | Source |
|---|---|
| Category | Cost/Security/Reliability/Performance/OperationalExcellence |
| Impact | High/Medium/Low |
| Resource ID | `resource_id` or `impacted_field` |
| Resource Name | Parsed from resource ID / `impacted_value` |
| Resource Type | Parsed from resource ID / `impacted_field` |
| Recommendation | `short_description.problem` |
| Solution | `short_description.solution` |
| Potential Savings | Extracted from `extended_properties` (cost recs) |
| Last Updated | `last_updated` |

## Test plan
- [ ] Run standalone: `python scripts/governance/advisor_export.py`
- [ ] Run from main menu → Governance → Advisor Recommendations
- [ ] Verify xlsx with correct columns, savings data for cost recommendations
- [ ] Run in CI mode: `AZURESCAN_AUTO_RUN=1 AZURESCAN_SUBSCRIPTIONS=<id> python azurescan.py`

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)