### PR TITLE
feat(monitoring): add metric alerts exporter

### DIFF
--- a/azurescan.py
+++ b/azurescan.py
@@ -63,6 +63,10 @@ TIER2_EXPORTERS = [
     ("VNet Peerings",                  "network/vnet_peerings_export.py"),
 ]
 
+MONITORING_EXPORTERS = [
+    ("Metric & Activity Log Alerts",   "monitoring/metric_alerts_export.py"),
+]
+
 
 # ---------------------------------------------------------------------------
 # Subscription resolution
@@ -189,14 +193,36 @@ def menu_tier2(sub_id: str, sub_name: str) -> None:
             _run_exporter(path, sub_id, sub_name)
 
 
+def menu_monitoring(sub_id: str, sub_name: str) -> None:
+    while True:
+        options = [label for label, _ in MONITORING_EXPORTERS] + ["Run All Monitoring Exporters"]
+        choice = utils.prompt_menu(
+            f"MONITORING EXPORTERS  ({sub_name})",
+            options,
+            allow_back=True,
+            allow_exit=True,
+        )
+        if choice == "back":
+            return
+        if choice == "exit":
+            sys.exit(0)
+        if choice == len(options):
+            _run_all_exporters(MONITORING_EXPORTERS, sub_id, sub_name)
+        else:
+            label, path = MONITORING_EXPORTERS[choice - 1]
+            print(f"\nRunning: {label}")
+            _run_exporter(path, sub_id, sub_name)
+
+
 def menu_main(sub_id: str, sub_name: str) -> None:
     _print_banner()
     while True:
         options = [
-            "Tier 1 Exporters  (Core infrastructure: VMs, VNets, Storage, Key Vault, RBAC…)",
-            "Tier 2 Exporters  (Workloads: AKS, App Service, SQL, Cosmos DB, Gateways…)",
-            "Run All Exporters  (Tier 1 + Tier 2)",
-            "Configure          (subscription selection, environment settings)",
+            "Tier 1 Exporters   (Core infrastructure: VMs, VNets, Storage, Key Vault, RBAC…)",
+            "Tier 2 Exporters   (Workloads: AKS, App Service, SQL, Cosmos DB, Gateways…)",
+            "Monitoring          (Alerts, Action Groups, Log Analytics…)",
+            "Run All Exporters   (Tier 1 + Tier 2 + Monitoring)",
+            "Configure           (subscription selection, environment settings)",
         ]
         choice = utils.prompt_menu(
             "AZURESCAN MAIN MENU",
@@ -212,8 +238,10 @@ def menu_main(sub_id: str, sub_name: str) -> None:
         elif choice == 2:
             menu_tier2(sub_id, sub_name)
         elif choice == 3:
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS, sub_id, sub_name)
+            menu_monitoring(sub_id, sub_name)
         elif choice == 4:
+            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + MONITORING_EXPORTERS, sub_id, sub_name)
+        elif choice == 5:
             subprocess.run([sys.executable, str(Path(__file__).parent / "configure.py")])
             # Reload config after configure
             import importlib
@@ -233,7 +261,7 @@ def main() -> None:
         for sid in all_subs:
             sname = utils.get_subscription_name(sid)
             print(f"\nAuto-run: scanning subscription {sname} ({sid})")
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS, sid, sname)
+            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + MONITORING_EXPORTERS, sid, sname)
         return
 
     menu_main(sub_id, sub_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "azure-mgmt-web>=7.0.0",
     "azure-mgmt-sql>=3.0.0",
     "azure-mgmt-cosmosdb>=9.0.0",
+    "azure-mgmt-monitor>=6.0.0",
     "pandas>=2.0.0",
     "openpyxl>=3.1.0",
     "python-dateutil>=2.8.2",

--- a/scripts/monitoring/metric_alerts_export.py
+++ b/scripts/monitoring/metric_alerts_export.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Metric Alerts & Activity Log Alerts Export"""
+
+import sys
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("metric-alerts-export")
+utils.log_script_start("metric_alerts_export.py", "Metric Alerts & Activity Log Alerts Export")
+
+log = utils.get_logger()
+
+
+def _format_criteria(criteria) -> str:
+    if not criteria:
+        return ""
+    parts = []
+    metric_triggers = getattr(criteria, "all_of", None) or []
+    for crit in metric_triggers:
+        metric = getattr(crit, "metric_name", "") or ""
+        operator = getattr(crit, "operator", "") or ""
+        threshold = getattr(crit, "threshold", "") or ""
+        if metric:
+            parts.append(f"{metric} {operator} {threshold}")
+    return "; ".join(parts) if parts else str(criteria)
+
+
+def _format_action_groups(actions) -> str:
+    if not actions:
+        return ""
+    names = []
+    for a in actions:
+        ag_id = getattr(a, "action_group_id", "") or ""
+        names.append(ag_id.split("/")[-1] if ag_id else "")
+    return ", ".join(n for n in names if n)
+
+
+def _format_scopes(scopes) -> str:
+    if not scopes:
+        return ""
+    return ", ".join(s.split("/")[-1] if "/" in s else s for s in scopes)
+
+
+def collect_metric_alerts(subscription_id: str) -> list:
+    client = utils.get_azure_client("monitor", subscription_id)
+    log.info("Listing metric alert rules for subscription %s", subscription_id)
+
+    rows = []
+    try:
+        for alert in client.metric_alerts.list_by_subscription():
+            rg = ""
+            alert_id = getattr(alert, "id", "") or ""
+            if "/resourceGroups/" in alert_id:
+                rg = alert_id.split("/resourceGroups/")[1].split("/")[0]
+
+            window = getattr(alert, "window_size", "") or ""
+            if hasattr(window, "total_seconds"):
+                mins = int(window.total_seconds() / 60)
+                window = f"{mins}m"
+
+            rows.append({
+                "Alert Name": getattr(alert, "name", "") or "",
+                "Resource Group": rg,
+                "Severity": getattr(alert, "severity", "") or "",
+                "Enabled": "Yes" if getattr(alert, "enabled", False) else "No",
+                "Target Resource": _format_scopes(getattr(alert, "scopes", None)),
+                "Condition": _format_criteria(getattr(alert, "criteria", None)),
+                "Window Size": str(window),
+                "Action Groups": _format_action_groups(getattr(alert, "actions", None)),
+                "Description": getattr(alert, "description", "") or "",
+            })
+    except Exception as e:
+        log.warning("Failed to list metric alerts: %s", e)
+
+    return rows
+
+
+def collect_activity_log_alerts(subscription_id: str) -> list:
+    client = utils.get_azure_client("monitor", subscription_id)
+    log.info("Listing activity log alert rules for subscription %s", subscription_id)
+
+    rows = []
+    try:
+        for alert in client.activity_log_alerts.list_by_subscription_id():
+            rg = ""
+            alert_id = getattr(alert, "id", "") or ""
+            if "/resourceGroups/" in alert_id:
+                rg = alert_id.split("/resourceGroups/")[1].split("/")[0]
+
+            conditions = []
+            condition = getattr(alert, "condition", None)
+            if condition:
+                all_of = getattr(condition, "all_of", None) or []
+                for c in all_of:
+                    field = getattr(c, "field", "") or ""
+                    equals = getattr(c, "equals", "") or ""
+                    if field:
+                        conditions.append(f"{field}={equals}")
+
+            actions_obj = getattr(alert, "actions", None)
+            action_groups = []
+            if actions_obj:
+                ag_list = getattr(actions_obj, "action_groups", None) or []
+                for ag in ag_list:
+                    ag_id = getattr(ag, "action_group_id", "") or ""
+                    action_groups.append(ag_id.split("/")[-1] if ag_id else "")
+
+            rows.append({
+                "Alert Name": getattr(alert, "name", "") or "",
+                "Resource Group": rg,
+                "Enabled": "Yes" if getattr(alert, "enabled", True) else "No",
+                "Scopes": _format_scopes(getattr(alert, "scopes", None)),
+                "Conditions": "; ".join(conditions),
+                "Action Groups": ", ".join(g for g in action_groups if g),
+                "Description": getattr(alert, "description", "") or "",
+            })
+    except Exception as e:
+        log.warning("Failed to list activity log alerts: %s", e)
+
+    return rows
+
+
+def main(subscription_id: str, subscription_name: str) -> None:
+    environment = utils.detect_environment()
+    if not utils.is_service_available_in_environment("resource", environment):
+        sys.exit(0)
+
+    metric_rows = collect_metric_alerts(subscription_id)
+    activity_rows = collect_activity_log_alerts(subscription_id)
+
+    if not metric_rows and not activity_rows:
+        print("No metric or activity log alerts found.")
+        return
+
+    sheets = {}
+    if metric_rows:
+        sheets["Metric Alerts"] = pd.DataFrame(metric_rows)
+    if activity_rows:
+        sheets["Activity Log Alerts"] = pd.DataFrame(activity_rows)
+
+    filename = utils.create_export_filename(subscription_name, "metric-alerts", "all")
+    utils.save_multiple_dataframes_to_excel(sheets, filename)
+    print(f"Exported {len(metric_rows)} metric alert(s), {len(activity_rows)} activity log alert(s) → {filename}")
+    log.info("Export complete: %d metric alerts, %d activity log alerts", len(metric_rows), len(activity_rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_id, sub_name)

--- a/utils.py
+++ b/utils.py
@@ -368,6 +368,7 @@ _CLIENT_MAP: Dict[str, tuple] = {
     "web": ("azure.mgmt.web", "WebSiteManagementClient", True),
     "sql": ("azure.mgmt.sql", "SqlManagementClient", True),
     "cosmosdb": ("azure.mgmt.cosmosdb", "CosmosDBManagementClient", True),
+    "monitor": ("azure.mgmt.monitor", "MonitorManagementClient", True),
 }
 
 # Government cloud base URL override


### PR DESCRIPTION
## Summary
- New exporter `scripts/monitoring/metric_alerts_export.py` — two-sheet xlsx with metric alerts and activity log alerts
- New category directory `scripts/monitoring/`
- Adds `monitor` (MonitorManagementClient) service to `_CLIENT_MAP` in utils.py
- Adds `azure-mgmt-monitor>=6.0.0` dependency to pyproject.toml
- Adds Monitoring menu tier to main menu (parallel to Governance tier from #22–#26)

## Sheets Exported

**Metric Alerts:** Alert Name, Resource Group, Severity, Enabled, Target Resource, Condition, Window Size, Action Groups, Description

**Activity Log Alerts:** Alert Name, Resource Group, Enabled, Scopes, Conditions, Action Groups, Description

## Test plan
- [ ] Run standalone: `python scripts/monitoring/metric_alerts_export.py`
- [ ] Run from main menu → Monitoring → Metric & Activity Log Alerts
- [ ] Verify xlsx has both sheets with correct columns
- [ ] Run in CI mode: `AZURESCAN_AUTO_RUN=1 AZURESCAN_SUBSCRIPTIONS=<id> python azurescan.py`

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)