### PR TITLE
feat(monitoring): add action groups exporter

### DIFF
--- a/azurescan.py
+++ b/azurescan.py
@@ -63,6 +63,10 @@ TIER2_EXPORTERS = [
     ("VNet Peerings",                  "network/vnet_peerings_export.py"),
 ]
 
+MONITORING_EXPORTERS = [
+    ("Action Groups",                  "monitoring/action_groups_export.py"),
+]
+
 
 # ---------------------------------------------------------------------------
 # Subscription resolution
@@ -189,14 +193,36 @@ def menu_tier2(sub_id: str, sub_name: str) -> None:
             _run_exporter(path, sub_id, sub_name)
 
 
+def menu_monitoring(sub_id: str, sub_name: str) -> None:
+    while True:
+        options = [label for label, _ in MONITORING_EXPORTERS] + ["Run All Monitoring Exporters"]
+        choice = utils.prompt_menu(
+            f"MONITORING EXPORTERS  ({sub_name})",
+            options,
+            allow_back=True,
+            allow_exit=True,
+        )
+        if choice == "back":
+            return
+        if choice == "exit":
+            sys.exit(0)
+        if choice == len(options):
+            _run_all_exporters(MONITORING_EXPORTERS, sub_id, sub_name)
+        else:
+            label, path = MONITORING_EXPORTERS[choice - 1]
+            print(f"\nRunning: {label}")
+            _run_exporter(path, sub_id, sub_name)
+
+
 def menu_main(sub_id: str, sub_name: str) -> None:
     _print_banner()
     while True:
         options = [
-            "Tier 1 Exporters  (Core infrastructure: VMs, VNets, Storage, Key Vault, RBAC…)",
-            "Tier 2 Exporters  (Workloads: AKS, App Service, SQL, Cosmos DB, Gateways…)",
-            "Run All Exporters  (Tier 1 + Tier 2)",
-            "Configure          (subscription selection, environment settings)",
+            "Tier 1 Exporters   (Core infrastructure: VMs, VNets, Storage, Key Vault, RBAC…)",
+            "Tier 2 Exporters   (Workloads: AKS, App Service, SQL, Cosmos DB, Gateways…)",
+            "Monitoring          (Alerts, Action Groups, Log Analytics…)",
+            "Run All Exporters   (Tier 1 + Tier 2 + Monitoring)",
+            "Configure           (subscription selection, environment settings)",
         ]
         choice = utils.prompt_menu(
             "AZURESCAN MAIN MENU",
@@ -212,8 +238,10 @@ def menu_main(sub_id: str, sub_name: str) -> None:
         elif choice == 2:
             menu_tier2(sub_id, sub_name)
         elif choice == 3:
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS, sub_id, sub_name)
+            menu_monitoring(sub_id, sub_name)
         elif choice == 4:
+            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + MONITORING_EXPORTERS, sub_id, sub_name)
+        elif choice == 5:
             subprocess.run([sys.executable, str(Path(__file__).parent / "configure.py")])
             # Reload config after configure
             import importlib
@@ -233,7 +261,7 @@ def main() -> None:
         for sid in all_subs:
             sname = utils.get_subscription_name(sid)
             print(f"\nAuto-run: scanning subscription {sname} ({sid})")
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS, sid, sname)
+            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + MONITORING_EXPORTERS, sid, sname)
         return
 
     menu_main(sub_id, sub_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "azure-mgmt-web>=7.0.0",
     "azure-mgmt-sql>=3.0.0",
     "azure-mgmt-cosmosdb>=9.0.0",
+    "azure-mgmt-monitor>=6.0.0",
     "pandas>=2.0.0",
     "openpyxl>=3.1.0",
     "python-dateutil>=2.8.2",

--- a/scripts/monitoring/action_groups_export.py
+++ b/scripts/monitoring/action_groups_export.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Action Groups Export"""
+
+import sys
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("action-groups-export")
+utils.log_script_start("action_groups_export.py", "Action Groups Export")
+
+log = utils.get_logger()
+
+
+def _format_receivers(receivers, name_attr: str, detail_attr: str = "") -> str:
+    if not receivers:
+        return ""
+    parts = []
+    for r in receivers:
+        name = getattr(r, name_attr, "") or ""
+        detail = getattr(r, detail_attr, "") if detail_attr else ""
+        if detail:
+            parts.append(f"{name} ({detail})")
+        else:
+            parts.append(name)
+    return ", ".join(parts)
+
+
+def collect_action_groups(subscription_id: str) -> list:
+    client = utils.get_azure_client("monitor", subscription_id)
+    log.info("Listing action groups for subscription %s", subscription_id)
+
+    rows = []
+    try:
+        for ag in client.action_groups.list_by_subscription_id():
+            rg = ""
+            ag_id = getattr(ag, "id", "") or ""
+            if "/resourceGroups/" in ag_id:
+                rg = ag_id.split("/resourceGroups/")[1].split("/")[0]
+
+            rows.append({
+                "Action Group Name": getattr(ag, "name", "") or "",
+                "Resource Group": rg,
+                "Short Name": getattr(ag, "group_short_name", "") or "",
+                "Enabled": "Yes" if getattr(ag, "enabled", True) else "No",
+                "Email Receivers": _format_receivers(
+                    getattr(ag, "email_receivers", None), "name", "email_address"
+                ),
+                "SMS Receivers": _format_receivers(
+                    getattr(ag, "sms_receivers", None), "name", "phone_number"
+                ),
+                "Webhook Receivers": _format_receivers(
+                    getattr(ag, "webhook_receivers", None), "name", "service_uri"
+                ),
+                "Azure App Push": _format_receivers(
+                    getattr(ag, "azure_app_push_receivers", None), "name", "email_address"
+                ),
+                "ITSM Receivers": _format_receivers(
+                    getattr(ag, "itsm_receivers", None), "name"
+                ),
+                "Automation Runbook": _format_receivers(
+                    getattr(ag, "automation_runbook_receivers", None), "name"
+                ),
+                "Azure Function": _format_receivers(
+                    getattr(ag, "azure_function_receivers", None), "name", "function_name"
+                ),
+                "Logic App": _format_receivers(
+                    getattr(ag, "logic_app_receivers", None), "name"
+                ),
+            })
+    except Exception as e:
+        log.warning("Failed to list action groups: %s", e)
+
+    return rows
+
+
+def main(subscription_id: str, subscription_name: str) -> None:
+    environment = utils.detect_environment()
+    if not utils.is_service_available_in_environment("resource", environment):
+        sys.exit(0)
+
+    rows = collect_action_groups(subscription_id)
+
+    if not rows:
+        print("No action groups found.")
+        return
+
+    df = pd.DataFrame(rows)
+    filename = utils.create_export_filename(subscription_name, "action-groups", "all")
+    utils.save_dataframe_to_excel(df, filename)
+    print(f"Exported {len(rows)} action group(s) → {filename}")
+    log.info("Export complete: %d action groups", len(rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_id, sub_name)

--- a/utils.py
+++ b/utils.py
@@ -368,6 +368,7 @@ _CLIENT_MAP: Dict[str, tuple] = {
     "web": ("azure.mgmt.web", "WebSiteManagementClient", True),
     "sql": ("azure.mgmt.sql", "SqlManagementClient", True),
     "cosmosdb": ("azure.mgmt.cosmosdb", "CosmosDBManagementClient", True),
+    "monitor": ("azure.mgmt.monitor", "MonitorManagementClient", True),
 }
 
 # Government cloud base URL override


### PR DESCRIPTION
## Summary
- New exporter `scripts/monitoring/action_groups_export.py` — exports action groups with all notification receiver types
- Reuses `monitor` (MonitorManagementClient) service from #27
- Adds `azure-mgmt-monitor>=6.0.0` dependency (overlaps with #27)
- Adds Monitoring menu tier (overlaps with #27)

## Fields Exported
| Column | Source |
|---|---|
| Action Group Name | `name` |
| Resource Group | Parsed from `id` |
| Short Name | `group_short_name` |
| Enabled | `enabled` |
| Email Receivers | `name (email_address)` comma-separated |
| SMS Receivers | `name (phone_number)` comma-separated |
| Webhook Receivers | `name (service_uri)` comma-separated |
| Azure App Push | `name (email_address)` comma-separated |
| ITSM Receivers | names comma-separated |
| Automation Runbook | names comma-separated |
| Azure Function | `name (function_name)` comma-separated |
| Logic App | names comma-separated |

## Test plan
- [ ] Run standalone: `python scripts/monitoring/action_groups_export.py`
- [ ] Run from main menu → Monitoring → Action Groups
- [ ] Verify xlsx with all receiver columns populated
- [ ] Run in CI mode

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)