### PR TITLE
feat(monitoring): add Log Analytics workspaces exporter

### DIFF
--- a/azurescan.py
+++ b/azurescan.py
@@ -63,6 +63,10 @@ TIER2_EXPORTERS = [
     ("VNet Peerings",                  "network/vnet_peerings_export.py"),
 ]
 
+MONITORING_EXPORTERS = [
+    ("Log Analytics Workspaces",       "monitoring/log_analytics_export.py"),
+]
+
 
 # ---------------------------------------------------------------------------
 # Subscription resolution
@@ -189,14 +193,36 @@ def menu_tier2(sub_id: str, sub_name: str) -> None:
             _run_exporter(path, sub_id, sub_name)
 
 
+def menu_monitoring(sub_id: str, sub_name: str) -> None:
+    while True:
+        options = [label for label, _ in MONITORING_EXPORTERS] + ["Run All Monitoring Exporters"]
+        choice = utils.prompt_menu(
+            f"MONITORING EXPORTERS  ({sub_name})",
+            options,
+            allow_back=True,
+            allow_exit=True,
+        )
+        if choice == "back":
+            return
+        if choice == "exit":
+            sys.exit(0)
+        if choice == len(options):
+            _run_all_exporters(MONITORING_EXPORTERS, sub_id, sub_name)
+        else:
+            label, path = MONITORING_EXPORTERS[choice - 1]
+            print(f"\nRunning: {label}")
+            _run_exporter(path, sub_id, sub_name)
+
+
 def menu_main(sub_id: str, sub_name: str) -> None:
     _print_banner()
     while True:
         options = [
-            "Tier 1 Exporters  (Core infrastructure: VMs, VNets, Storage, Key Vault, RBAC…)",
-            "Tier 2 Exporters  (Workloads: AKS, App Service, SQL, Cosmos DB, Gateways…)",
-            "Run All Exporters  (Tier 1 + Tier 2)",
-            "Configure          (subscription selection, environment settings)",
+            "Tier 1 Exporters   (Core infrastructure: VMs, VNets, Storage, Key Vault, RBAC…)",
+            "Tier 2 Exporters   (Workloads: AKS, App Service, SQL, Cosmos DB, Gateways…)",
+            "Monitoring          (Alerts, Action Groups, Log Analytics…)",
+            "Run All Exporters   (Tier 1 + Tier 2 + Monitoring)",
+            "Configure           (subscription selection, environment settings)",
         ]
         choice = utils.prompt_menu(
             "AZURESCAN MAIN MENU",
@@ -212,8 +238,10 @@ def menu_main(sub_id: str, sub_name: str) -> None:
         elif choice == 2:
             menu_tier2(sub_id, sub_name)
         elif choice == 3:
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS, sub_id, sub_name)
+            menu_monitoring(sub_id, sub_name)
         elif choice == 4:
+            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + MONITORING_EXPORTERS, sub_id, sub_name)
+        elif choice == 5:
             subprocess.run([sys.executable, str(Path(__file__).parent / "configure.py")])
             # Reload config after configure
             import importlib
@@ -233,7 +261,7 @@ def main() -> None:
         for sid in all_subs:
             sname = utils.get_subscription_name(sid)
             print(f"\nAuto-run: scanning subscription {sname} ({sid})")
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS, sid, sname)
+            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + MONITORING_EXPORTERS, sid, sname)
         return
 
     menu_main(sub_id, sub_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "azure-mgmt-web>=7.0.0",
     "azure-mgmt-sql>=3.0.0",
     "azure-mgmt-cosmosdb>=9.0.0",
+    "azure-mgmt-loganalytics>=13.0.0",
     "pandas>=2.0.0",
     "openpyxl>=3.1.0",
     "python-dateutil>=2.8.2",

--- a/scripts/monitoring/log_analytics_export.py
+++ b/scripts/monitoring/log_analytics_export.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Log Analytics Workspaces Export"""
+
+import sys
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("log-analytics-export")
+utils.log_script_start("log_analytics_export.py", "Log Analytics Workspaces Export")
+
+log = utils.get_logger()
+
+
+def collect_workspaces(subscription_id: str) -> list:
+    client = utils.get_azure_client("loganalytics", subscription_id)
+    log.info("Listing Log Analytics workspaces for subscription %s", subscription_id)
+
+    rows = []
+    try:
+        for ws in client.workspaces.list():
+            rg = ""
+            ws_id = getattr(ws, "id", "") or ""
+            if "/resourceGroups/" in ws_id:
+                rg = ws_id.split("/resourceGroups/")[1].split("/")[0]
+
+            sku_name = ""
+            sku = getattr(ws, "sku", None)
+            if sku:
+                sku_name = getattr(sku, "name", "") or ""
+
+            daily_cap = ""
+            cap = getattr(ws, "workspace_capping", None)
+            if cap:
+                quota = getattr(cap, "daily_quota_gb", None)
+                if quota is not None and quota >= 0:
+                    daily_cap = f"{quota} GB"
+
+            created = getattr(ws, "created_date", "") or ""
+            if hasattr(created, "isoformat"):
+                created = created.isoformat()
+
+            modified = getattr(ws, "modified_date", "") or ""
+            if hasattr(modified, "isoformat"):
+                modified = modified.isoformat()
+
+            rows.append({
+                "Workspace Name": getattr(ws, "name", "") or "",
+                "Resource Group": rg,
+                "Location": getattr(ws, "location", "") or "",
+                "SKU": sku_name,
+                "Retention (days)": getattr(ws, "retention_in_days", "") or "",
+                "Daily Cap": daily_cap,
+                "Provisioning State": getattr(ws, "provisioning_state", "") or "",
+                "Created Date": created,
+                "Modified Date": modified,
+            })
+    except Exception as e:
+        log.warning("Failed to list Log Analytics workspaces: %s", e)
+
+    return rows
+
+
+def main(subscription_id: str, subscription_name: str) -> None:
+    environment = utils.detect_environment()
+    if not utils.is_service_available_in_environment("resource", environment):
+        sys.exit(0)
+
+    rows = collect_workspaces(subscription_id)
+
+    if not rows:
+        print("No Log Analytics workspaces found.")
+        return
+
+    df = pd.DataFrame(rows)
+    filename = utils.create_export_filename(subscription_name, "log-analytics", "all")
+    utils.save_dataframe_to_excel(df, filename)
+    print(f"Exported {len(rows)} workspace(s) → {filename}")
+    log.info("Export complete: %d workspaces", len(rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_id, sub_name)

--- a/utils.py
+++ b/utils.py
@@ -368,6 +368,7 @@ _CLIENT_MAP: Dict[str, tuple] = {
     "web": ("azure.mgmt.web", "WebSiteManagementClient", True),
     "sql": ("azure.mgmt.sql", "SqlManagementClient", True),
     "cosmosdb": ("azure.mgmt.cosmosdb", "CosmosDBManagementClient", True),
+    "loganalytics": ("azure.mgmt.loganalytics", "LogAnalyticsManagementClient", True),
 }
 
 # Government cloud base URL override


### PR DESCRIPTION
## Summary
- New exporter `scripts/monitoring/log_analytics_export.py` — exports Log Analytics workspace configuration
- Adds `loganalytics` (LogAnalyticsManagementClient) service to `_CLIENT_MAP` in utils.py
- Adds `azure-mgmt-loganalytics>=13.0.0` dependency to pyproject.toml
- Adds Monitoring menu tier (merges cleanly with #27 and #28)

## Fields Exported
| Column | Source |
|---|---|
| Workspace Name | `name` |
| Resource Group | Parsed from `id` |
| Location | `location` |
| SKU | `sku.name` |
| Retention (days) | `retention_in_days` |
| Daily Cap | `workspace_capping.daily_quota_gb` |
| Provisioning State | `provisioning_state` |
| Created Date | `created_date` |
| Modified Date | `modified_date` |

## Test plan
- [ ] Run standalone: `python scripts/monitoring/log_analytics_export.py`
- [ ] Run from main menu → Monitoring → Log Analytics Workspaces
- [ ] Verify xlsx with correct columns, retention and cap values
- [ ] Run in CI mode

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)