### PR TITLE
feat(governance): Cost Management export + CloudShell/Government hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,12 @@ Sibling project to [StratusScan-CLI (AWS)](https://github.com/ColonelPanicX/Stra
 
 ### Azure Cloud Shell (recommended)
 
-The tool is designed to work in a fresh [Azure Cloud Shell](https://shell.azure.com) session with no extra setup. Credentials are injected automatically.
+The tool is designed to work in a fresh [Azure Cloud Shell](https://shell.azure.com) session with no extra setup. Credentials are injected automatically, and `configure.py` / `azurescan.py` install their own dependencies on first run.
 
 ```bash
 git clone https://github.com/ColonelPanicX/stratusscan-cli-azure.git
 cd stratusscan-cli-azure
-pip install -r <(python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); print('\n'.join(d['project']['dependencies']))")
-python configure.py
+python configure.py    # installs dependencies on first run
 python azurescan.py
 ```
 
@@ -49,16 +48,10 @@ Requires [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) in
 git clone https://github.com/ColonelPanicX/stratusscan-cli-azure.git
 cd stratusscan-cli-azure
 
-# Install dependencies
-pip install azure-identity azure-mgmt-resource azure-mgmt-compute azure-mgmt-network \
-    azure-mgmt-storage azure-mgmt-keyvault azure-mgmt-authorization \
-    azure-mgmt-containerservice azure-mgmt-web azure-mgmt-sql azure-mgmt-cosmosdb \
-    pandas openpyxl python-dateutil questionary
-
 # Authenticate
 az login
 
-# Configure subscription and environment
+# Configure subscription and environment (installs dependencies on first run)
 python configure.py
 
 # Launch AzureScan

--- a/azurescan.py
+++ b/azurescan.py
@@ -155,7 +155,7 @@ def _package_outputs() -> None:
     print(f"  In Cloud Shell, download it with:  download {zip_path}")
 
 
-def _run_all_exporters(exporters: list, sub_id: str, sub_name: str) -> None:
+def _run_all_exporters(exporters: list, sub_id: str, sub_name: str, package: bool = True) -> None:
     print(f"\nRunning {len(exporters)} exporter(s)...\n")
     failed = []
     for label, path in exporters:
@@ -171,6 +171,25 @@ def _run_all_exporters(exporters: list, sub_id: str, sub_name: str) -> None:
         print(f"Completed with {len(failed)} failure(s): {', '.join(failed)}")
     else:
         print(f"All {len(exporters)} exporter(s) completed successfully.")
+    if package:
+        _package_outputs()
+
+
+def _run_all_for_configured_subscriptions(exporters: list, fallback_sub_id: str, fallback_sub_name: str) -> None:
+    """Iterate the given exporters across every subscription saved in config."""
+    configured = utils.get_config().get("subscriptions") or []
+    subs = configured if configured else [{"id": fallback_sub_id, "name": fallback_sub_name}]
+
+    if len(subs) > 1:
+        print(f"\nScanning {len(subs)} subscription(s)...")
+
+    for sub in subs:
+        sid = sub["id"]
+        sname = sub.get("name") or utils.get_subscription_name(sid)
+        if len(subs) > 1:
+            print(f"\n========== Subscription: {sname} ({sid}) ==========")
+        _run_all_exporters(exporters, sid, sname, package=False)
+
     _package_outputs()
 
 
@@ -292,7 +311,11 @@ def menu_main(sub_id: str, sub_name: str) -> None:
         elif choice == 4:
             menu_monitoring(sub_id, sub_name)
         elif choice == 5:
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS + MONITORING_EXPORTERS, sub_id, sub_name)
+            _run_all_for_configured_subscriptions(
+                TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS + MONITORING_EXPORTERS,
+                sub_id,
+                sub_name,
+            )
         elif choice == 6:
             _package_outputs()
         elif choice == 7:

--- a/azurescan.py
+++ b/azurescan.py
@@ -16,8 +16,13 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Ensure utils is importable from the project root
+# Ensure local modules are importable from the project root
 sys.path.insert(0, str(Path(__file__).parent))
+
+# CloudShell-first: install dependencies before importing utils (which pulls
+# in the Azure SDKs and pandas). No manual pip step required.
+import bootstrap
+bootstrap.ensure_dependencies()
 
 try:
     import utils

--- a/azurescan.py
+++ b/azurescan.py
@@ -146,6 +146,15 @@ def _print_banner() -> None:
     print("=" * 64)
 
 
+def _package_outputs() -> None:
+    zip_path = utils.archive_outputs()
+    if not zip_path:
+        print("\nNo exports found in output/ to package.")
+        return
+    print(f"\nPackaged all exports → {zip_path}")
+    print(f"  In Cloud Shell, download it with:  download {zip_path}")
+
+
 def _run_all_exporters(exporters: list, sub_id: str, sub_name: str) -> None:
     print(f"\nRunning {len(exporters)} exporter(s)...\n")
     failed = []
@@ -162,6 +171,7 @@ def _run_all_exporters(exporters: list, sub_id: str, sub_name: str) -> None:
         print(f"Completed with {len(failed)} failure(s): {', '.join(failed)}")
     else:
         print(f"All {len(exporters)} exporter(s) completed successfully.")
+    _package_outputs()
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +271,7 @@ def menu_main(sub_id: str, sub_name: str) -> None:
             "Governance          (Policy, Management Groups, Defender, Advisor…)",
             "Monitoring          (Alerts, Action Groups, Log Analytics…)",
             "Run All Exporters   (Tier 1 + Tier 2 + Governance + Monitoring)",
+            "Package Outputs     (zip all exports for one-click download)",
             "Configure           (subscription selection, environment settings)",
         ]
         choice = utils.prompt_menu(
@@ -283,6 +294,8 @@ def menu_main(sub_id: str, sub_name: str) -> None:
         elif choice == 5:
             _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS + MONITORING_EXPORTERS, sub_id, sub_name)
         elif choice == 6:
+            _package_outputs()
+        elif choice == 7:
             subprocess.run([sys.executable, str(Path(__file__).parent / "configure.py")])
             # Reload config after configure
             import importlib

--- a/azurescan.py
+++ b/azurescan.py
@@ -70,6 +70,7 @@ GOVERNANCE_EXPORTERS = [
     ("Defender Secure Scores & Plans", "security/defender_scores_export.py"),
     ("Defender Assessments",           "security/defender_assessments_export.py"),
     ("Advisor Recommendations",        "governance/advisor_export.py"),
+    ("Cost Management (Month-to-Date)", "governance/cost_management_export.py"),
 ]
 
 MONITORING_EXPORTERS = [

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -10,9 +10,13 @@ Stdlib-only — safe to import before any dependency is installed.
 """
 
 import importlib
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+# Guards against an install loop if a package is still missing after install.
+_ATTEMPTED_ENV = "AZURESCAN_BOOTSTRAP_ATTEMPTED"
 
 # Representative modules — the exact submodules utils imports. We attempt a
 # real import (not find_spec) because `azure` is a namespace package: a spec
@@ -60,8 +64,20 @@ def ensure_dependencies() -> None:
     missing = [m for m in _REQUIRED_MODULES if _is_missing(m)]
     if not missing:
         return
+
+    if os.environ.get(_ATTEMPTED_ENV):
+        # Already installed once this session but something is still missing.
+        # Don't loop — let the real import error surface downstream.
+        print(f"WARNING: dependencies still unavailable after install: {', '.join(missing)}")
+        return
+
     print(f"Installing required dependencies (missing: {', '.join(missing)})...")
     deps = _read_pyproject_dependencies()
     subprocess.run([sys.executable, "-m", "pip", "install", *deps], check=True)
-    importlib.invalidate_caches()
-    print("Dependencies installed.\n")
+    print("Dependencies installed. Restarting...\n")
+
+    # Re-exec in a clean interpreter. Probing the imports above populated the
+    # `azure` namespace package's cached __path__ before the packages existed;
+    # a fresh process is the reliable way to pick up the new install.
+    os.environ[_ATTEMPTED_ENV] = "1"
+    os.execv(sys.executable, [sys.executable, *sys.argv])

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+StratusScanCLI-Azure — Dependency bootstrap.
+
+CloudShell-first: the CLI entry points (azurescan.py, configure.py) call
+ensure_dependencies() before importing utils, which pulls in the Azure SDKs
+and pandas. This removes the manual `pip install` step from the quick start.
+
+Stdlib-only — safe to import before any dependency is installed.
+"""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+# Representative modules — if any are missing, (re)install from pyproject.
+_REQUIRED_MODULES = [
+    "azure.identity",
+    "azure.mgmt.resource",
+    "azure.mgmt.costmanagement",
+    "pandas",
+    "openpyxl",
+    "dateutil",
+]
+
+
+def _read_pyproject_dependencies() -> list:
+    pyproject = Path(__file__).parent / "pyproject.toml"
+    try:
+        import tomllib  # Python 3.11+
+        with open(pyproject, "rb") as f:
+            return tomllib.load(f)["project"]["dependencies"]
+    except ModuleNotFoundError:
+        # Fallback for Python 3.9/3.10 (no tomllib): read the
+        # dependencies = [ ... ] array literally.
+        text = pyproject.read_text()
+        start = text.index("dependencies = [")
+        end = text.index("]", start)
+        deps = []
+        for line in text[start:end].splitlines()[1:]:
+            line = line.strip().strip(",").strip()
+            if line.startswith(('"', "'")):
+                deps.append(line.strip("\"'"))
+        return deps
+
+
+def _is_missing(module: str) -> bool:
+    # find_spec raises (rather than returning None) when a parent package is
+    # entirely absent, e.g. checking "azure.identity" when "azure" isn't there.
+    try:
+        return importlib.util.find_spec(module) is None
+    except ModuleNotFoundError:
+        return True
+
+
+def ensure_dependencies() -> None:
+    missing = [m for m in _REQUIRED_MODULES if _is_missing(m)]
+    if not missing:
+        return
+    print("Installing required dependencies (first run, this may take a minute)...")
+    deps = _read_pyproject_dependencies()
+    subprocess.run([sys.executable, "-m", "pip", "install", *deps], check=True)
+    print("Dependencies installed.\n")

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -9,15 +9,18 @@ and pandas. This removes the manual `pip install` step from the quick start.
 Stdlib-only — safe to import before any dependency is installed.
 """
 
-import importlib.util
+import importlib
 import subprocess
 import sys
 from pathlib import Path
 
-# Representative modules — if any are missing, (re)install from pyproject.
+# Representative modules — the exact submodules utils imports. We attempt a
+# real import (not find_spec) because `azure` is a namespace package: a spec
+# can resolve for azure.mgmt.resource while the client submodule is absent.
 _REQUIRED_MODULES = [
     "azure.identity",
-    "azure.mgmt.resource",
+    "azure.mgmt.resource.resources",
+    "azure.mgmt.resource.subscriptions",
     "azure.mgmt.costmanagement",
     "pandas",
     "openpyxl",
@@ -46,11 +49,10 @@ def _read_pyproject_dependencies() -> list:
 
 
 def _is_missing(module: str) -> bool:
-    # find_spec raises (rather than returning None) when a parent package is
-    # entirely absent, e.g. checking "azure.identity" when "azure" isn't there.
     try:
-        return importlib.util.find_spec(module) is None
-    except ModuleNotFoundError:
+        importlib.import_module(module)
+        return False
+    except ImportError:
         return True
 
 
@@ -58,7 +60,8 @@ def ensure_dependencies() -> None:
     missing = [m for m in _REQUIRED_MODULES if _is_missing(m)]
     if not missing:
         return
-    print("Installing required dependencies (first run, this may take a minute)...")
+    print(f"Installing required dependencies (missing: {', '.join(missing)})...")
     deps = _read_pyproject_dependencies()
     subprocess.run([sys.executable, "-m", "pip", "install", *deps], check=True)
+    importlib.invalidate_caches()
     print("Dependencies installed.\n")

--- a/configure.py
+++ b/configure.py
@@ -11,6 +11,7 @@ Usage:
 """
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -162,6 +163,12 @@ def main() -> None:
 
     environment = select_environment()
     log.info("Environment selected: %s", environment)
+
+    # Apply the choice before discovery so the credential targets the right
+    # cloud (gov managed identities reject the public management audience).
+    os.environ["AZURE_ENVIRONMENT"] = (
+        "AzureUSGovernment" if environment == "government" else "AzurePublicCloud"
+    )
 
     subs = discover_subscriptions()
     selected = select_subscriptions(subs)

--- a/configure.py
+++ b/configure.py
@@ -16,6 +16,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
+# CloudShell-first: install dependencies before importing utils.
+import bootstrap
+bootstrap.ensure_dependencies()
+
 try:
     import utils
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,7 @@ classifiers = [
 
 dependencies = [
     "azure-identity>=1.15.0",
-    "azure-mgmt-resource>=23.0.0",
-    "azure-mgmt-resource-subscriptions>=1.0.0",
+    "azure-mgmt-resource>=23.0.0,<25.0.0",
     "azure-mgmt-compute>=30.0.0",
     "azure-mgmt-network>=25.0.0",
     "azure-mgmt-storage>=21.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     "azure-mgmt-advisor>=9.0.0",
     "azure-mgmt-monitor>=6.0.0",
     "azure-mgmt-loganalytics>=13.0.0",
+    "azure-mgmt-costmanagement>=4.0.0",
     "pandas>=2.0.0",
     "openpyxl>=3.1.0",
     "python-dateutil>=2.8.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ classifiers = [
 dependencies = [
     "azure-identity>=1.15.0",
     "azure-mgmt-resource>=23.0.0",
+    "azure-mgmt-resource-subscriptions>=1.0.0",
     "azure-mgmt-compute>=30.0.0",
     "azure-mgmt-network>=25.0.0",
     "azure-mgmt-storage>=21.0.0",

--- a/scripts/compute/aks_clusters_export.py
+++ b/scripts/compute/aks_clusters_export.py
@@ -36,7 +36,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
     rows = []
     for cluster in clusters:
-        rg = cluster.id.split("/resourceGroups/")[1].split("/")[0] if cluster.id else ""
+        rg = utils.extract_resource_group(cluster.id)
         tags = cluster.tags or {}
         agent_pools = cluster.agent_pool_profiles or []
         total_nodes = sum(p.count or 0 for p in agent_pools)

--- a/scripts/compute/aks_clusters_export.py
+++ b/scripts/compute/aks_clusters_export.py
@@ -69,9 +69,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/compute/app_service_export.py
+++ b/scripts/compute/app_service_export.py
@@ -71,9 +71,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/compute/app_service_export.py
+++ b/scripts/compute/app_service_export.py
@@ -39,7 +39,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
     rows = []
     for app in apps:
         rg = app.resource_group or (
-            app.id.split("/resourceGroups/")[1].split("/")[0] if app.id else ""
+            utils.extract_resource_group(app.id)
         )
         tags = app.tags or {}
         rows.append({

--- a/scripts/compute/function_apps_export.py
+++ b/scripts/compute/function_apps_export.py
@@ -69,9 +69,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/compute/function_apps_export.py
+++ b/scripts/compute/function_apps_export.py
@@ -38,7 +38,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
     rows = []
     for app in apps:
         rg = app.resource_group or (
-            app.id.split("/resourceGroups/")[1].split("/")[0] if app.id else ""
+            utils.extract_resource_group(app.id)
         )
         tags = app.tags or {}
         rows.append({

--- a/scripts/compute/managed_disks_export.py
+++ b/scripts/compute/managed_disks_export.py
@@ -55,7 +55,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
     rows = []
     for disk in disks:
-        rg = disk.id.split("/resourceGroups/")[1].split("/")[0] if disk.id else ""
+        rg = utils.extract_resource_group(disk.id)
         tags = disk.tags or {}
         rows.append({
             "Name": disk.name,

--- a/scripts/compute/managed_disks_export.py
+++ b/scripts/compute/managed_disks_export.py
@@ -80,9 +80,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/compute/virtual_machines_export.py
+++ b/scripts/compute/virtual_machines_export.py
@@ -87,9 +87,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/compute/virtual_machines_export.py
+++ b/scripts/compute/virtual_machines_export.py
@@ -58,7 +58,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
     rows = []
     for vm in vms:
         tags = vm.tags or {}
-        rg = vm.id.split("/resourceGroups/")[1].split("/")[0] if vm.id else ""
+        rg = utils.extract_resource_group(vm.id)
         rows.append({
             "Name": vm.name,
             "Resource Group": rg,

--- a/scripts/databases/azure_sql_export.py
+++ b/scripts/databases/azure_sql_export.py
@@ -24,7 +24,7 @@ def collect_sql_servers_and_dbs(subscription_id: str) -> list:
     servers = list(client.servers.list())
     rows = []
     for server in servers:
-        rg = server.id.split("/resourceGroups/")[1].split("/")[0] if server.id else ""
+        rg = utils.extract_resource_group(server.id)
         try:
             databases = list(client.databases.list_by_server(rg, server.name))
         except Exception as exc:

--- a/scripts/databases/azure_sql_export.py
+++ b/scripts/databases/azure_sql_export.py
@@ -72,9 +72,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/databases/cosmos_db_export.py
+++ b/scripts/databases/cosmos_db_export.py
@@ -68,9 +68,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/databases/cosmos_db_export.py
+++ b/scripts/databases/cosmos_db_export.py
@@ -36,7 +36,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
     rows = []
     for acct in accounts:
-        rg = acct.id.split("/resourceGroups/")[1].split("/")[0] if acct.id else ""
+        rg = utils.extract_resource_group(acct.id)
         tags = acct.tags or {}
         locations = ", ".join(
             loc.location_name for loc in (acct.locations or []) if loc.location_name

--- a/scripts/governance/advisor_export.py
+++ b/scripts/governance/advisor_export.py
@@ -100,9 +100,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/governance/cost_management_export.py
+++ b/scripts/governance/cost_management_export.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Cost Management Export (month-to-date actual cost)"""
+
+import sys
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("cost-management-export")
+utils.log_script_start("cost_management_export.py", "Azure Cost Management Export")
+
+log = utils.get_logger()
+
+# Actual cost, month-to-date, grouped by resource group and service.
+# Passed as a plain dict so it deserializes across azure-mgmt-costmanagement versions.
+_QUERY = {
+    "type": "ActualCost",
+    "timeframe": "MonthToDate",
+    "dataset": {
+        "granularity": "None",
+        "aggregation": {"totalCost": {"name": "Cost", "function": "Sum"}},
+        "grouping": [
+            {"type": "Dimension", "name": "ResourceGroupName"},
+            {"type": "Dimension", "name": "ServiceName"},
+        ],
+    },
+}
+
+
+def collect_costs(subscription_id: str) -> list:
+    client = utils.get_azure_client("costmanagement", subscription_id)
+    scope = f"/subscriptions/{subscription_id}"
+    log.info("Querying month-to-date cost for subscription %s", subscription_id)
+
+    rows = []
+    try:
+        result = client.query.usage(scope=scope, parameters=_QUERY)
+        columns = [getattr(c, "name", "") for c in (result.columns or [])]
+        for raw in (result.rows or []):
+            rows.append(dict(zip(columns, raw)))
+    except Exception as e:
+        log.warning("Failed to query Cost Management: %s", e)
+
+    return rows
+
+
+def main(subscription_id: str, subscription_name: str) -> None:
+    environment = utils.detect_environment()
+    if not utils.is_service_available_in_environment("resource", environment):
+        sys.exit(0)
+
+    rows = collect_costs(subscription_id)
+
+    if not rows:
+        print("No cost data found for the current billing period.")
+        return
+
+    df = pd.DataFrame(rows)
+    filename = utils.create_export_filename(subscription_name, "cost-management", "mtd")
+    utils.save_dataframe_to_excel(df, filename)
+    print(f"Exported {len(rows)} cost row(s) → {filename}")
+    log.info("Export complete: %d cost rows", len(rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_id, sub_name)

--- a/scripts/governance/cost_management_export.py
+++ b/scripts/governance/cost_management_export.py
@@ -69,9 +69,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/governance/management_groups_export.py
+++ b/scripts/governance/management_groups_export.py
@@ -44,7 +44,17 @@ def collect_management_groups() -> list:
     client = utils.get_azure_client("managementgroups")
     log.info("Listing management groups")
 
-    groups = list(client.management_groups.list())
+    try:
+        groups = list(client.management_groups.list())
+    except Exception as e:
+        if "AuthorizationFailed" in str(e):
+            print(
+                "Skipping: your account lacks permission to read management groups "
+                "(Microsoft.Management/managementGroups/read)."
+            )
+            log.warning("Management group listing not authorized: %s", e)
+            return []
+        raise
     log.info("Found %d management group(s), fetching details", len(groups))
 
     rows = []

--- a/scripts/governance/management_groups_export.py
+++ b/scripts/governance/management_groups_export.py
@@ -96,9 +96,7 @@ def main(subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/governance/policy_assignments_export.py
+++ b/scripts/governance/policy_assignments_export.py
@@ -177,9 +177,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/governance/policy_assignments_export.py
+++ b/scripts/governance/policy_assignments_export.py
@@ -90,7 +90,7 @@ def _scope_label(scope: str) -> str:
     if "/managementGroups/" in scope:
         return scope.split("/managementGroups/")[-1]
     if "/resourceGroups/" in scope:
-        return scope.split("/resourceGroups/")[-1].split("/")[0]
+        return utils.extract_resource_group(scope)
     if "/subscriptions/" in scope:
         return "subscription"
     return scope

--- a/scripts/monitoring/action_groups_export.py
+++ b/scripts/monitoring/action_groups_export.py
@@ -42,7 +42,7 @@ def collect_action_groups(subscription_id: str) -> list:
             rg = ""
             ag_id = getattr(ag, "id", "") or ""
             if "/resourceGroups/" in ag_id:
-                rg = ag_id.split("/resourceGroups/")[1].split("/")[0]
+                rg = utils.extract_resource_group(ag_id)
 
             rows.append({
                 "Action Group Name": getattr(ag, "name", "") or "",

--- a/scripts/monitoring/action_groups_export.py
+++ b/scripts/monitoring/action_groups_export.py
@@ -99,9 +99,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/monitoring/log_analytics_export.py
+++ b/scripts/monitoring/log_analytics_export.py
@@ -86,9 +86,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/monitoring/log_analytics_export.py
+++ b/scripts/monitoring/log_analytics_export.py
@@ -28,7 +28,7 @@ def collect_workspaces(subscription_id: str) -> list:
             rg = ""
             ws_id = getattr(ws, "id", "") or ""
             if "/resourceGroups/" in ws_id:
-                rg = ws_id.split("/resourceGroups/")[1].split("/")[0]
+                rg = utils.extract_resource_group(ws_id)
 
             sku_name = ""
             sku = getattr(ws, "sku", None)

--- a/scripts/monitoring/metric_alerts_export.py
+++ b/scripts/monitoring/metric_alerts_export.py
@@ -152,9 +152,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/monitoring/metric_alerts_export.py
+++ b/scripts/monitoring/metric_alerts_export.py
@@ -58,7 +58,7 @@ def collect_metric_alerts(subscription_id: str) -> list:
             rg = ""
             alert_id = getattr(alert, "id", "") or ""
             if "/resourceGroups/" in alert_id:
-                rg = alert_id.split("/resourceGroups/")[1].split("/")[0]
+                rg = utils.extract_resource_group(alert_id)
 
             window = getattr(alert, "window_size", "") or ""
             if hasattr(window, "total_seconds"):
@@ -92,7 +92,7 @@ def collect_activity_log_alerts(subscription_id: str) -> list:
             rg = ""
             alert_id = getattr(alert, "id", "") or ""
             if "/resourceGroups/" in alert_id:
-                rg = alert_id.split("/resourceGroups/")[1].split("/")[0]
+                rg = utils.extract_resource_group(alert_id)
 
             conditions = []
             condition = getattr(alert, "condition", None)

--- a/scripts/network/application_gateway_export.py
+++ b/scripts/network/application_gateway_export.py
@@ -36,7 +36,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
     rows = []
     for gw in gateways:
-        rg = gw.id.split("/resourceGroups/")[1].split("/")[0] if gw.id else ""
+        rg = utils.extract_resource_group(gw.id)
         tags = gw.tags or {}
         rows.append({
             "Name": gw.name,

--- a/scripts/network/application_gateway_export.py
+++ b/scripts/network/application_gateway_export.py
@@ -69,9 +69,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/network/azure_firewall_export.py
+++ b/scripts/network/azure_firewall_export.py
@@ -64,9 +64,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/network/azure_firewall_export.py
+++ b/scripts/network/azure_firewall_export.py
@@ -36,7 +36,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
     rows = []
     for fw in firewalls:
-        rg = fw.id.split("/resourceGroups/")[1].split("/")[0] if fw.id else ""
+        rg = utils.extract_resource_group(fw.id)
         tags = fw.tags or {}
         policy_id = ""
         if fw.firewall_policy and fw.firewall_policy.id:

--- a/scripts/network/firewall_policy_rules_export.py
+++ b/scripts/network/firewall_policy_rules_export.py
@@ -119,7 +119,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
     rows = []
     for policy in policies:
-        policy_rg = policy.id.split("/resourceGroups/")[1].split("/")[0] if policy.id else ""
+        policy_rg = utils.extract_resource_group(policy.id)
         policy_name = policy.name or ""
 
         try:

--- a/scripts/network/firewall_policy_rules_export.py
+++ b/scripts/network/firewall_policy_rules_export.py
@@ -172,9 +172,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/network/load_balancers_export.py
+++ b/scripts/network/load_balancers_export.py
@@ -63,9 +63,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/network/load_balancers_export.py
+++ b/scripts/network/load_balancers_export.py
@@ -36,7 +36,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
     rows = []
     for lb in lbs:
-        rg = lb.id.split("/resourceGroups/")[1].split("/")[0] if lb.id else ""
+        rg = utils.extract_resource_group(lb.id)
         tags = lb.tags or {}
         frontend_ips = len(lb.frontend_ip_configurations or [])
         backend_pools = len(lb.backend_address_pools or [])

--- a/scripts/network/network_security_groups_export.py
+++ b/scripts/network/network_security_groups_export.py
@@ -36,7 +36,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
     rows = []
     for nsg in nsgs:
-        rg = nsg.id.split("/resourceGroups/")[1].split("/")[0] if nsg.id else ""
+        rg = utils.extract_resource_group(nsg.id)
         tags = nsg.tags or {}
         inbound = len(nsg.security_rules or [])
         default_inbound = len(nsg.default_security_rules or [])

--- a/scripts/network/network_security_groups_export.py
+++ b/scripts/network/network_security_groups_export.py
@@ -72,9 +72,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/network/public_ips_export.py
+++ b/scripts/network/public_ips_export.py
@@ -51,7 +51,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
     rows = []
     for pip in pips:
-        rg = pip.id.split("/resourceGroups/")[1].split("/")[0] if pip.id else ""
+        rg = utils.extract_resource_group(pip.id)
         tags = pip.tags or {}
         rows.append({
             "Name": pip.name,

--- a/scripts/network/public_ips_export.py
+++ b/scripts/network/public_ips_export.py
@@ -85,9 +85,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/network/route_tables_export.py
+++ b/scripts/network/route_tables_export.py
@@ -59,9 +59,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/network/route_tables_export.py
+++ b/scripts/network/route_tables_export.py
@@ -36,7 +36,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
     rows = []
     for rt in tables:
-        rg = rt.id.split("/resourceGroups/")[1].split("/")[0] if rt.id else ""
+        rg = utils.extract_resource_group(rt.id)
         tags = rt.tags or {}
         routes = rt.routes or []
         associated_subnets = len(rt.subnets or [])

--- a/scripts/network/subnets_export.py
+++ b/scripts/network/subnets_export.py
@@ -24,7 +24,7 @@ def collect_subnets(subscription_id: str) -> list:
     log.info("Scanning subnets across %d VNets", len(vnets))
     rows = []
     for vnet in vnets:
-        vnet_rg = vnet.id.split("/resourceGroups/")[1].split("/")[0] if vnet.id else ""
+        vnet_rg = utils.extract_resource_group(vnet.id)
         for subnet in (vnet.subnets or []):
             nsg_name = ""
             if subnet.network_security_group and subnet.network_security_group.id:

--- a/scripts/network/subnets_export.py
+++ b/scripts/network/subnets_export.py
@@ -63,9 +63,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/network/virtual_networks_export.py
+++ b/scripts/network/virtual_networks_export.py
@@ -64,9 +64,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/network/virtual_networks_export.py
+++ b/scripts/network/virtual_networks_export.py
@@ -36,7 +36,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
     rows = []
     for vnet in vnets:
-        rg = vnet.id.split("/resourceGroups/")[1].split("/")[0] if vnet.id else ""
+        rg = utils.extract_resource_group(vnet.id)
         tags = vnet.tags or {}
         address_space = ", ".join(
             vnet.address_space.address_prefixes

--- a/scripts/network/vnet_peerings_export.py
+++ b/scripts/network/vnet_peerings_export.py
@@ -24,7 +24,7 @@ def collect_peerings(subscription_id: str) -> list:
     log.info("Scanning peerings across %d VNets", len(vnets))
     rows = []
     for vnet in vnets:
-        vnet_rg = vnet.id.split("/resourceGroups/")[1].split("/")[0] if vnet.id else ""
+        vnet_rg = utils.extract_resource_group(vnet.id)
         for peering in (vnet.virtual_network_peerings or []):
             remote_vnet = ""
             if peering.remote_virtual_network and peering.remote_virtual_network.id:

--- a/scripts/network/vnet_peerings_export.py
+++ b/scripts/network/vnet_peerings_export.py
@@ -67,9 +67,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/resource_groups_export.py
+++ b/scripts/resource_groups_export.py
@@ -52,9 +52,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/security/defender_assessments_export.py
+++ b/scripts/security/defender_assessments_export.py
@@ -104,9 +104,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/security/defender_scores_export.py
+++ b/scripts/security/defender_scores_export.py
@@ -97,9 +97,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/security/key_vault_export.py
+++ b/scripts/security/key_vault_export.py
@@ -45,7 +45,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
     rows = []
     for vault_ref in vaults_summary:
-        rg = vault_ref.id.split("/resourceGroups/")[1].split("/")[0] if vault_ref.id else ""
+        rg = utils.extract_resource_group(vault_ref.id)
         vault = _get_vault_detail(client, rg, vault_ref.name)
         if vault is None:
             continue

--- a/scripts/security/key_vault_export.py
+++ b/scripts/security/key_vault_export.py
@@ -73,9 +73,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/security/role_assignments_export.py
+++ b/scripts/security/role_assignments_export.py
@@ -78,9 +78,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/storage/storage_accounts_export.py
+++ b/scripts/storage/storage_accounts_export.py
@@ -36,7 +36,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
     rows = []
     for acct in accounts:
-        rg = acct.id.split("/resourceGroups/")[1].split("/")[0] if acct.id else ""
+        rg = utils.extract_resource_group(acct.id)
         tags = acct.tags or {}
         rows.append({
             "Name": acct.name,

--- a/scripts/storage/storage_accounts_export.py
+++ b/scripts/storage/storage_accounts_export.py
@@ -66,9 +66,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/utils.py
+++ b/utils.py
@@ -303,9 +303,11 @@ def detect_environment() -> str:
     2. config.json 'environment' key
     3. Default: 'public'
     """
-    env_var = os.environ.get("AZURE_ENVIRONMENT", "").strip()
-    if env_var.lower() in ("azureusgovernment", "government", "usgov"):
+    env_var = os.environ.get("AZURE_ENVIRONMENT", "").strip().lower()
+    if env_var in ("azureusgovernment", "government", "usgov"):
         return "government"
+    if env_var in ("azurepubliccloud", "public", "azurecloud"):
+        return "public"
     cfg = get_config()
     if cfg.get("environment", "public").lower() in ("government", "azureusgovernment"):
         return "government"

--- a/utils.py
+++ b/utils.py
@@ -417,6 +417,7 @@ def get_azure_client(service_name: str, subscription_id: Optional[str] = None) -
     kwargs: Dict[str, Any] = {}
     if environment == "government":
         kwargs["base_url"] = _GOV_BASE_URL
+        kwargs["credential_scopes"] = [f"{_GOV_BASE_URL}/.default"]
 
     if needs_sub:
         return cls(cred, subscription_id, **kwargs)

--- a/utils.py
+++ b/utils.py
@@ -163,6 +163,27 @@ def create_export_filename(subscription_name: str, resource_type: str, suffix: s
     return str(out_dir / filename)
 
 
+def archive_outputs() -> Optional[str]:
+    """
+    Bundle every .xlsx in output/ into a single dated zip in output/.
+
+    Returns the zip path, or None if there are no exports to archive.
+    The zip itself is excluded so re-runs don't nest prior archives.
+    """
+    import zipfile
+
+    out_dir = Path(__file__).parent / "output"
+    exports = sorted(p for p in out_dir.glob("*.xlsx"))
+    if not exports:
+        return None
+
+    zip_path = out_dir / f"stratusscan-exports-{get_current_timestamp()}.zip"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for export in exports:
+            zf.write(export, arcname=export.name)
+    return str(zip_path)
+
+
 # ---------------------------------------------------------------------------
 # Excel output
 # ---------------------------------------------------------------------------

--- a/utils.py
+++ b/utils.py
@@ -357,8 +357,8 @@ def _get_credential():
 
 # Lazy import map: service_name → (module_path, class_name, needs_subscription_id)
 _CLIENT_MAP: Dict[str, tuple] = {
-    "subscription": ("azure.mgmt.resource", "SubscriptionClient", False),
-    "resource": ("azure.mgmt.resource", "ResourceManagementClient", True),
+    "subscription": ("azure.mgmt.resource.subscriptions", "SubscriptionClient", False),
+    "resource": ("azure.mgmt.resource.resources", "ResourceManagementClient", True),
     "compute": ("azure.mgmt.compute", "ComputeManagementClient", True),
     "network": ("azure.mgmt.network", "NetworkManagementClient", True),
     "storage": ("azure.mgmt.storage", "StorageManagementClient", True),

--- a/utils.py
+++ b/utils.py
@@ -382,6 +382,13 @@ _CLIENT_MAP: Dict[str, tuple] = {
 # Government cloud base URL override
 _GOV_BASE_URL = "https://management.usgovcloudapi.net"
 
+# Some azure-mgmt SDKs default to an api-version not yet available in Azure
+# Government, which lags public cloud. Pin a gov-supported version per service.
+# Only add services that actually fail; the override is applied only in gov.
+_GOV_API_VERSIONS: Dict[str, str] = {
+    "storage": "2025-06-01",
+}
+
 
 def get_azure_client(service_name: str, subscription_id: Optional[str] = None) -> Any:
     """
@@ -420,6 +427,8 @@ def get_azure_client(service_name: str, subscription_id: Optional[str] = None) -
     if environment == "government":
         kwargs["base_url"] = _GOV_BASE_URL
         kwargs["credential_scopes"] = [f"{_GOV_BASE_URL}/.default"]
+        if key in _GOV_API_VERSIONS:
+            kwargs["api_version"] = _GOV_API_VERSIONS[key]
 
     if needs_sub:
         return cls(cred, subscription_id, **kwargs)

--- a/utils.py
+++ b/utils.py
@@ -90,6 +90,12 @@ def setup_logging(script_name: str = "azurescan", log_to_file: bool = True) -> l
         except Exception as exc:
             logger.warning("File logging unavailable: %s", exc)
 
+    # Quiet noisy third-party loggers. The Azure SDK deserializer emits a
+    # WARNING ("Discriminator source is absent...") per resource, and the HTTP
+    # policy logs full request/response — neither belongs on the console.
+    for noisy in ("azure", "msrest", "urllib3"):
+        logging.getLogger(noisy).setLevel(logging.ERROR)
+
     _logging_configured = True
     return logger
 
@@ -408,6 +414,7 @@ _GOV_BASE_URL = "https://management.usgovcloudapi.net"
 # Only add services that actually fail; the override is applied only in gov.
 _GOV_API_VERSIONS: Dict[str, str] = {
     "storage": "2025-06-01",
+    "web": "2025-03-01",
 }
 
 

--- a/utils.py
+++ b/utils.py
@@ -515,6 +515,19 @@ def get_subscription_name(subscription_id: str) -> str:
     return subscription_id
 
 
+def resolve_target_subscription() -> tuple:
+    """
+    Return (subscription_id, subscription_name) for the exporter to scan.
+
+    Prefers AZURESCAN_SUBSCRIPTION_ID/NAME env vars set by azurescan.py when
+    iterating across multiple subscriptions; falls back to the default in
+    config.json for standalone exporter runs.
+    """
+    sub_id = os.environ.get("AZURESCAN_SUBSCRIPTION_ID") or get_config().get("default_subscription_id", "")
+    sub_name = os.environ.get("AZURESCAN_SUBSCRIPTION_NAME") or get_subscription_name(sub_id)
+    return sub_id, sub_name
+
+
 # ---------------------------------------------------------------------------
 # Interactive menu (shared by azurescan.py and configure.py)
 # ---------------------------------------------------------------------------

--- a/utils.py
+++ b/utils.py
@@ -374,6 +374,7 @@ _CLIENT_MAP: Dict[str, tuple] = {
     "advisor": ("azure.mgmt.advisor", "AdvisorManagementClient", True),
     "monitor": ("azure.mgmt.monitor", "MonitorManagementClient", True),
     "loganalytics": ("azure.mgmt.loganalytics", "LogAnalyticsManagementClient", True),
+    "costmanagement": ("azure.mgmt.costmanagement", "CostManagementClient", False),
 }
 
 # Government cloud base URL override

--- a/utils.py
+++ b/utils.py
@@ -169,6 +169,22 @@ def create_export_filename(subscription_name: str, resource_type: str, suffix: s
     return str(out_dir / filename)
 
 
+def extract_resource_group(resource_id: Optional[str]) -> str:
+    """
+    Return the resource group name from an Azure resource ID, or "" if absent.
+
+    Case-insensitive: Azure returns the segment as both '/resourceGroups/' and
+    '/resourcegroups/' depending on the API, so a literal split is unsafe.
+    """
+    if not resource_id:
+        return ""
+    parts = resource_id.split("/")
+    for i, part in enumerate(parts):
+        if part.lower() == "resourcegroups" and i + 1 < len(parts):
+            return parts[i + 1]
+    return ""
+
+
 def archive_outputs() -> Optional[str]:
     """
     Bundle every .xlsx in output/ into a single dated zip in output/.

--- a/utils.py
+++ b/utils.py
@@ -431,6 +431,7 @@ _GOV_BASE_URL = "https://management.usgovcloudapi.net"
 _GOV_API_VERSIONS: Dict[str, str] = {
     "storage": "2025-06-01",
     "web": "2025-03-01",
+    "costmanagement": "2023-03-01",
 }
 
 


### PR DESCRIPTION
## Summary

Started as the Cost Management month-to-date export, then expanded to make the tool run cleanly end-to-end in a fresh **Azure Government Cloud Shell**.

### Cost Management export
- Adds `scripts/governance/cost_management_export.py` — exports month-to-date **ActualCost** via the Cost Management Query API, grouped by Resource Group + Service.
- Registers `costmanagement` in `utils._CLIENT_MAP` (`needs_sub=False`, scope-based) and in the Governance menu.
- Adds `azure-mgmt-costmanagement>=4.0.0`.

### CloudShell-first dependency bootstrap
- New `bootstrap.py`: `configure.py` / `azurescan.py` install their own dependencies on first run (no manual `pip install`).
- Detects missing deps via real imports (not `find_spec`, which is fooled by the `azure` namespace package).
- Re-execs the interpreter after install so freshly-installed packages are visible (avoids the stale namespace-cache `azure-mgmt-resource-subscriptions` error).

### Azure Government fixes
- `configure.py` applies the environment choice **before** subscription discovery, so the credential targets the gov token audience (`management.usgovcloudapi.net`) instead of failing with `AudienceNotSupported`.
- `detect_environment()` now honors an explicit `AzurePublicCloud` env var over stale config.
- Per-service gov **API-version override map** (`_GOV_API_VERSIONS`) for services whose SDK default isn't available in Government yet: `storage` 2025-06-01, `web` 2025-03-01, `costmanagement` 2023-03-01.
- Caps `azure-mgmt-resource<25.0.0` so the bundled `azure.mgmt.resource.subscriptions` stays available.

### Robustness across all exporters
- New `utils.extract_resource_group()` — case-insensitive, crash-safe. Replaces the fragile `id.split("/resourceGroups/")[1]` pattern in 20+ exporters that raised `IndexError` on casing differences.
- Management Groups exporter handles `AuthorizationFailed` gracefully (skip + message) instead of crashing the run.
- Silences noisy Azure SDK loggers (`azure`/`msrest`/`urllib3` → ERROR) to stop the per-resource "Discriminator source is absent..." console spam.

### Output convenience
- `utils.archive_outputs()` + "Package Outputs" menu option + auto-package after Run All: bundles every export into a single dated zip and prints the Cloud Shell `download` command.

## Test plan
- [x] Fresh Government Cloud Shell: `git clone` → checkout branch → `python configure.py` auto-installs deps and discovers subscriptions
- [x] Run All exporters in Government — storage, web, cost management, firewall policy rules, management groups all complete or skip cleanly
- [ ] Verify on a Public-cloud subscription (no regression from gov changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)