### PR TITLE
feat(governance): add cost management month-to-date export

### DIFF
--- a/azurescan.py
+++ b/azurescan.py
@@ -70,6 +70,7 @@ GOVERNANCE_EXPORTERS = [
     ("Defender Secure Scores & Plans", "defender_scores_export.py"),
     ("Defender Assessments",           "defender_assessments_export.py"),
     ("Advisor Recommendations",        "advisor_export.py"),
+    ("Cost Management (Month-to-Date)", "cost_management_export.py"),
 ]
 
 MONITORING_EXPORTERS = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     "azure-mgmt-advisor>=9.0.0",
     "azure-mgmt-monitor>=6.0.0",
     "azure-mgmt-loganalytics>=13.0.0",
+    "azure-mgmt-costmanagement>=4.0.0",
     "pandas>=2.0.0",
     "openpyxl>=3.1.0",
     "python-dateutil>=2.8.2",

--- a/scripts/cost_management_export.py
+++ b/scripts/cost_management_export.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Cost Management Export (month-to-date actual cost)"""
+
+import sys
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("cost-management-export")
+utils.log_script_start("cost_management_export.py", "Azure Cost Management Export")
+
+log = utils.get_logger()
+
+_QUERY = {
+    "type": "ActualCost",
+    "timeframe": "MonthToDate",
+    "dataset": {
+        "granularity": "None",
+        "aggregation": {"totalCost": {"name": "Cost", "function": "Sum"}},
+        "grouping": [
+            {"type": "Dimension", "name": "ResourceGroupName"},
+            {"type": "Dimension", "name": "ServiceName"},
+        ],
+    },
+}
+
+
+def collect_costs(subscription_id: str) -> list:
+    client = utils.get_azure_client("costmanagement")
+    scope = f"/subscriptions/{subscription_id}"
+    log.info("Querying month-to-date cost for subscription %s", subscription_id)
+
+    rows = []
+    try:
+        result = client.query.usage(scope=scope, parameters=_QUERY)
+        columns = [getattr(c, "name", "") for c in (result.columns or [])]
+        for raw in result.rows or []:
+            rows.append(dict(zip(columns, raw)))
+    except Exception as e:
+        log.warning("Failed to query Cost Management: %s", e)
+
+    return rows
+
+
+def main(subscription_id: str, subscription_name: str) -> None:
+    environment = utils.detect_environment()
+    if not utils.is_service_available_in_environment("costmanagement", environment):
+        sys.exit(0)
+
+    rows = collect_costs(subscription_id)
+
+    if not rows:
+        print("No cost data found for the current billing period.")
+        return
+
+    df = pd.DataFrame(rows)
+    filename = utils.create_export_filename(subscription_name, "cost-management", "mtd")
+    utils.save_dataframe_to_excel(df, filename)
+    print(f"Exported {len(rows)} cost row(s) → {filename}")
+    log.info("Export complete: %d cost rows", len(rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_id, sub_name)

--- a/utils.py
+++ b/utils.py
@@ -374,6 +374,7 @@ _CLIENT_MAP: Dict[str, tuple] = {
     "advisor": ("azure.mgmt.advisor", "AdvisorManagementClient", True),
     "monitor": ("azure.mgmt.monitor", "MonitorManagementClient", True),
     "loganalytics": ("azure.mgmt.loganalytics", "LogAnalyticsManagementClient", True),
+    "costmanagement": ("azure.mgmt.costmanagement", "CostManagementClient", False),
 }
 
 # Government cloud base URL override


### PR DESCRIPTION
## Summary
- Add a flat `scripts/cost_management_export.py` exporter for month-to-date actual cost
- Register the Cost Management SDK client and dependency
- Add the exporter to the Governance menu and run-all registry

## Testing
- python -m py_compile scripts/cost_management_export.py azurescan.py utils.py
- git diff --check

Closes #32