### PR TITLE
feat: add output archive command

### DIFF
--- a/azurescan.py
+++ b/azurescan.py
@@ -158,6 +158,15 @@ def _run_all_exporters(exporters: list, sub_id: str, sub_name: str) -> None:
         print(f"All {len(exporters)} exporter(s) completed successfully.")
 
 
+def _package_outputs() -> None:
+    zip_path = utils.archive_outputs()
+    if not zip_path:
+        print("\nNo exports found in output/ to package.")
+        return
+    print(f"\nPackaged exports → {zip_path}")
+    print(f"  In Cloud Shell, download it with: download {zip_path}")
+
+
 # ---------------------------------------------------------------------------
 # Menus
 # ---------------------------------------------------------------------------
@@ -255,6 +264,7 @@ def menu_main(sub_id: str, sub_name: str) -> None:
             "Governance          (Policy, Management Groups, Defender, Advisor…)",
             "Monitoring          (Alerts, Action Groups, Log Analytics…)",
             "Run All Exporters   (Tier 1 + Tier 2 + Governance + Monitoring)",
+            "Package Outputs     (zip all exports for Cloud Shell download)",
             "Configure           (subscription selection, environment settings)",
         ]
         choice = utils.prompt_menu(
@@ -277,6 +287,8 @@ def menu_main(sub_id: str, sub_name: str) -> None:
         elif choice == 5:
             _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS + MONITORING_EXPORTERS, sub_id, sub_name)
         elif choice == 6:
+            _package_outputs()
+        elif choice == 7:
             subprocess.run([sys.executable, str(Path(__file__).parent / "configure.py")])
             # Reload config after configure
             import importlib

--- a/utils.py
+++ b/utils.py
@@ -163,6 +163,26 @@ def create_export_filename(subscription_name: str, resource_type: str, suffix: s
     return str(out_dir / filename)
 
 
+def archive_outputs() -> Optional[str]:
+    """
+    Bundle every .xlsx in output/ into a single dated zip.
+
+    Returns the zip path, or None if there are no exports to archive.
+    """
+    import zipfile
+
+    out_dir = Path(__file__).parent / "output"
+    exports = sorted(out_dir.glob("*.xlsx"))
+    if not exports:
+        return None
+
+    zip_path = out_dir / f"exports-{get_current_timestamp()}.zip"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for export in exports:
+            zf.write(export, arcname=export.name)
+    return str(zip_path)
+
+
 # ---------------------------------------------------------------------------
 # Excel output
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `utils.archive_outputs()` to zip `.xlsx` exports from `output/`
- Add a main-menu command to package exports for Cloud Shell download

## Testing
- python -m py_compile azurescan.py utils.py
- git diff --check
- Created a temporary `.xlsx`, verified `utils.archive_outputs()` produced `output/exports-06.03.2026.zip`, then removed test artifacts

Closes #34