### PR TITLE
feat(compute): VMSS, Snapshots, Availability Sets exporters

### DIFF
--- a/azurescan.py
+++ b/azurescan.py
@@ -40,6 +40,7 @@ TIER1_EXPORTERS = [
     ("Subscriptions",                  "subscriptions_export.py"),
     ("Resource Groups",                "resource_groups_export.py"),
     ("Virtual Machines",               "virtual_machines_export.py"),
+    ("VM Scale Sets",                  "vmss_export.py"),
     ("Managed Disks",                  "managed_disks_export.py"),
     ("Virtual Networks",               "virtual_networks_export.py"),
     ("Subnets",                        "subnets_export.py"),
@@ -62,6 +63,8 @@ TIER2_EXPORTERS = [
     ("Firewall Policy Rules",          "firewall_policy_rules_export.py"),
     ("Route Tables",                   "route_tables_export.py"),
     ("VNet Peerings",                  "vnet_peerings_export.py"),
+    ("Snapshots",                      "snapshots_export.py"),
+    ("Availability Sets",              "availability_sets_export.py"),
 ]
 
 GOVERNANCE_EXPORTERS = [

--- a/scripts/availability_sets_export.py
+++ b/scripts/availability_sets_export.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Availability Sets Export"""
+
+import sys
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("availability-sets-export")
+utils.log_script_start("availability_sets_export.py", "Availability Sets Export")
+
+log = utils.get_logger()
+
+
+def collect_availability_sets(subscription_id: str) -> list:
+    client = utils.get_azure_client("compute", subscription_id)
+    log.info("Listing all availability sets in subscription %s", subscription_id)
+    return list(client.availability_sets.list_by_subscription())
+
+
+def _member_vms(avset) -> list:
+    try:
+        return [vm.id.split("/")[-1] for vm in (avset.virtual_machines or []) if vm.id]
+    except Exception:
+        return []
+
+
+def _proximity_placement_group(avset) -> str:
+    try:
+        if avset.proximity_placement_group and avset.proximity_placement_group.id:
+            return avset.proximity_placement_group.id.split("/")[-1]
+    except Exception:
+        pass
+    return ""
+
+
+def main(subscription_id: str, subscription_name: str) -> None:
+    environment = utils.detect_environment()
+    if not utils.is_service_available_in_environment("compute", environment):
+        sys.exit(0)
+
+    avsets = collect_availability_sets(subscription_id)
+    if not avsets:
+        print("No availability sets found.")
+        return
+
+    rows = []
+    for avset in avsets:
+        rg = avset.id.split("/resourceGroups/")[1].split("/")[0] if avset.id else ""
+        vms = _member_vms(avset)
+        tags = avset.tags or {}
+        rows.append({
+            "Name": avset.name,
+            "Resource Group": rg,
+            "Location": avset.location,
+            "Fault Domain Count": avset.platform_fault_domain_count if avset.platform_fault_domain_count is not None else "",
+            "Update Domain Count": avset.platform_update_domain_count if avset.platform_update_domain_count is not None else "",
+            "SKU": avset.sku.name if avset.sku else "",
+            "VM Count": len(vms),
+            "VMs": ", ".join(vms),
+            "Proximity Placement Group": _proximity_placement_group(avset),
+            "Tags": "; ".join(f"{k}={v}" for k, v in tags.items()),
+        })
+
+    df = pd.DataFrame(rows)
+    filename = utils.create_export_filename(subscription_name, "availability-sets", "all")
+    utils.save_dataframe_to_excel(df, filename, sheet_name="Availability Sets")
+    print(f"Exported {len(rows)} availability set(s) → {filename}")
+    log.info("Export complete: %d availability sets", len(rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_id, sub_name)

--- a/scripts/snapshots_export.py
+++ b/scripts/snapshots_export.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Disk Snapshots Export"""
+
+import sys
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("snapshots-export")
+utils.log_script_start("snapshots_export.py", "Disk Snapshots Export")
+
+log = utils.get_logger()
+
+
+def collect_snapshots(subscription_id: str) -> list:
+    client = utils.get_azure_client("compute", subscription_id)
+    log.info("Listing all snapshots in subscription %s", subscription_id)
+    return list(client.snapshots.list())
+
+
+def collect_disk_ids(subscription_id: str) -> set:
+    client = utils.get_azure_client("compute", subscription_id)
+    return {disk.id.lower() for disk in client.disks.list() if disk.id}
+
+
+def _source_disk_id(snapshot) -> str:
+    try:
+        return snapshot.creation_data.source_resource_id or ""
+    except Exception:
+        return ""
+
+
+def main(subscription_id: str, subscription_name: str) -> None:
+    environment = utils.detect_environment()
+    if not utils.is_service_available_in_environment("compute", environment):
+        sys.exit(0)
+
+    snapshots = collect_snapshots(subscription_id)
+    if not snapshots:
+        print("No snapshots found.")
+        return
+
+    existing_disks = collect_disk_ids(subscription_id)
+
+    rows = []
+    for snap in snapshots:
+        rg = snap.id.split("/resourceGroups/")[1].split("/")[0] if snap.id else ""
+        source_id = _source_disk_id(snap)
+        source_name = source_id.split("/")[-1] if source_id else ""
+        source_rg = ""
+        if "/resourceGroups/" in source_id:
+            source_rg = source_id.split("/resourceGroups/")[1].split("/")[0]
+
+        is_disk_source = "/disks/" in source_id.lower()
+        if not source_id or not is_disk_source:
+            orphaned = "N/A"
+        else:
+            orphaned = "No" if source_id.lower() in existing_disks else "Yes"
+
+        tags = snap.tags or {}
+        rows.append({
+            "Name": snap.name,
+            "Resource Group": rg,
+            "Location": snap.location,
+            "Source Disk": source_name,
+            "Source Resource Group": source_rg,
+            "OS Type": str(snap.os_type) if snap.os_type else "Data",
+            "Disk Size GB": snap.disk_size_gb or "",
+            "SKU": snap.sku.name if snap.sku else "",
+            "Time Created": str(snap.time_created) if snap.time_created else "",
+            "Incremental": "Yes" if snap.incremental else "No",
+            "Orphaned": orphaned,
+            "Provisioning State": snap.provisioning_state or "",
+            "Tags": "; ".join(f"{k}={v}" for k, v in tags.items()),
+        })
+
+    df = pd.DataFrame(rows)
+    filename = utils.create_export_filename(subscription_name, "snapshots", "all")
+    utils.save_dataframe_to_excel(df, filename, sheet_name="Snapshots")
+    print(f"Exported {len(rows)} snapshot(s) → {filename}")
+    log.info("Export complete: %d snapshots", len(rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_id, sub_name)

--- a/scripts/vmss_export.py
+++ b/scripts/vmss_export.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Virtual Machine Scale Sets Export"""
+
+import sys
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("vmss-export")
+utils.log_script_start("vmss_export.py", "Virtual Machine Scale Sets Export")
+
+log = utils.get_logger()
+
+
+def collect_scale_sets(subscription_id: str) -> list:
+    client = utils.get_azure_client("compute", subscription_id)
+    log.info("Listing all VM scale sets in subscription %s", subscription_id)
+    return list(client.virtual_machine_scale_sets.list_all())
+
+
+def _os_type(vmss) -> str:
+    try:
+        profile = vmss.virtual_machine_profile
+        os_disk = profile.storage_profile.os_disk
+        if os_disk and os_disk.os_type:
+            return str(os_disk.os_type)
+    except Exception:
+        pass
+    return ""
+
+
+def _admin_username(vmss) -> str:
+    try:
+        return vmss.virtual_machine_profile.os_profile.admin_username or ""
+    except Exception:
+        return ""
+
+
+def _upgrade_policy(vmss) -> str:
+    try:
+        if vmss.upgrade_policy and vmss.upgrade_policy.mode:
+            return str(vmss.upgrade_policy.mode)
+    except Exception:
+        pass
+    return ""
+
+
+def main(subscription_id: str, subscription_name: str) -> None:
+    environment = utils.detect_environment()
+    if not utils.is_service_available_in_environment("compute", environment):
+        sys.exit(0)
+
+    scale_sets = collect_scale_sets(subscription_id)
+    if not scale_sets:
+        print("No VM scale sets found.")
+        return
+
+    rows = []
+    for vmss in scale_sets:
+        rg = vmss.id.split("/resourceGroups/")[1].split("/")[0] if vmss.id else ""
+        tags = vmss.tags or {}
+        rows.append({
+            "Name": vmss.name,
+            "Resource Group": rg,
+            "Location": vmss.location,
+            "SKU Name": vmss.sku.name if vmss.sku else "",
+            "SKU Capacity": vmss.sku.capacity if vmss.sku else "",
+            "Upgrade Policy": _upgrade_policy(vmss),
+            "Orchestration Mode": str(vmss.orchestration_mode) if vmss.orchestration_mode else "",
+            "OS Type": _os_type(vmss),
+            "Admin Username": _admin_username(vmss),
+            "Provisioning State": vmss.provisioning_state or "",
+            "Overprovision": "Yes" if vmss.overprovision else "No",
+            "Tags": "; ".join(f"{k}={v}" for k, v in tags.items()),
+        })
+
+    df = pd.DataFrame(rows)
+    filename = utils.create_export_filename(subscription_name, "vmss", "all")
+    utils.save_dataframe_to_excel(df, filename, sheet_name="VM Scale Sets")
+    print(f"Exported {len(rows)} VM scale set(s) → {filename}")
+    log.info("Export complete: %d scale sets", len(rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_id, sub_name)


### PR DESCRIPTION
## Quick-win sweep — compute category

Three new exporters, all using `ComputeManagementClient` (already in `_CLIENT_MAP`) — **zero new SDK dependencies**.

| Script | Issue | Menu | Notes |
|---|---|---|---|
| `vmss_export.py` | #40 | Tier 1 | VM Scale Sets — `virtual_machine_scale_sets.list_all()` |
| `snapshots_export.py` | #56 | Tier 2 | Disk snapshots, includes `Orphaned` flag (source disk gone) |
| `availability_sets_export.py` | #57 | Tier 2 | Availability sets with VM membership list |

All follow the standard exporter pattern (subprocess-runnable, `utils.get_azure_client`, `is_service_available_in_environment` guard, Excel output via `utils`). Compile-checked locally.

**Testing:** Not yet validated against a live subscription — @monkizzle to verify column accuracy and live API behavior post-merge.

Closes #40, #56, #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)