### PR TITLE
feat(governance): Resource Locks, Tags Inventory, Custom Policy Definitions exporters

### DIFF
--- a/azurescan.py
+++ b/azurescan.py
@@ -70,6 +70,9 @@ GOVERNANCE_EXPORTERS = [
     ("Defender Secure Scores & Plans", "defender_scores_export.py"),
     ("Defender Assessments",           "defender_assessments_export.py"),
     ("Advisor Recommendations",        "advisor_export.py"),
+    ("Resource Locks",                 "resource_locks_export.py"),
+    ("Resource Tags Inventory",        "resource_tags_export.py"),
+    ("Custom Policy Definitions",      "policy_definitions_export.py"),
 ]
 
 MONITORING_EXPORTERS = [

--- a/scripts/policy_definitions_export.py
+++ b/scripts/policy_definitions_export.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Custom Policy Definitions Export"""
+
+import sys
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("policy-definitions-export")
+utils.log_script_start("policy_definitions_export.py", "Custom Policy Definitions Export")
+
+log = utils.get_logger()
+
+
+def collect_definitions(subscription_id: str) -> list:
+    client = utils.get_azure_client("policy", subscription_id)
+    log.info("Listing custom policy definitions in subscription %s", subscription_id)
+    return [d for d in client.policy_definitions.list() if str(getattr(d, "policy_type", "")) == "Custom"]
+
+
+def _metadata_value(definition, key: str) -> str:
+    metadata = getattr(definition, "metadata", None) or {}
+    if isinstance(metadata, dict):
+        return str(metadata.get(key, "") or "")
+    return ""
+
+
+def _effect(definition) -> str:
+    try:
+        rule = getattr(definition, "policy_rule", None) or {}
+        then = rule.get("then", {}) if isinstance(rule, dict) else {}
+        return str(then.get("effect", "") or "")
+    except Exception:
+        return ""
+
+
+def main(subscription_id: str, subscription_name: str) -> None:
+    environment = utils.detect_environment()
+    if not utils.is_service_available_in_environment("policy", environment):
+        sys.exit(0)
+
+    definitions = collect_definitions(subscription_id)
+    if not definitions:
+        print("No custom policy definitions found.")
+        return
+
+    rows = []
+    for d in definitions:
+        params = getattr(d, "parameters", None) or {}
+        rows.append({
+            "Name": d.name or "",
+            "Display Name": getattr(d, "display_name", "") or "",
+            "Description": getattr(d, "description", "") or "",
+            "Policy Type": str(getattr(d, "policy_type", "")) or "",
+            "Mode": getattr(d, "mode", "") or "",
+            "Category": _metadata_value(d, "category"),
+            "Effect": _effect(d),
+            "Parameter Count": len(params),
+            "Version": _metadata_value(d, "version"),
+            "Created By": _metadata_value(d, "createdBy"),
+            "Created Date": _metadata_value(d, "createdOn"),
+        })
+
+    df = pd.DataFrame(rows)
+    filename = utils.create_export_filename(subscription_name, "policy-definitions", "custom")
+    utils.save_dataframe_to_excel(df, filename, sheet_name="Custom Policy Definitions")
+    print(f"Exported {len(rows)} custom policy definition(s) → {filename}")
+    log.info("Export complete: %d custom policy definitions", len(rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_id, sub_name)

--- a/scripts/resource_locks_export.py
+++ b/scripts/resource_locks_export.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Resource Locks Export"""
+
+import sys
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("resource-locks-export")
+utils.log_script_start("resource_locks_export.py", "Resource Locks Export")
+
+log = utils.get_logger()
+
+
+def collect_locks(subscription_id: str) -> list:
+    client = utils.get_azure_client("locks", subscription_id)
+    log.info("Listing all management locks in subscription %s", subscription_id)
+    return list(client.management_locks.list_at_subscription_level())
+
+
+def _scope(lock) -> str:
+    lock_id = getattr(lock, "id", "") or ""
+    marker = "/providers/Microsoft.Authorization/locks/"
+    return lock_id.split(marker)[0] if marker in lock_id else lock_id
+
+
+def _resource_group(scope: str) -> str:
+    if "/resourceGroups/" in scope:
+        return scope.split("/resourceGroups/")[1].split("/")[0]
+    return ""
+
+
+def _resource_name_and_type(scope: str) -> tuple:
+    if "/providers/" not in scope:
+        return "", ""
+    tail = scope.split("/providers/", 1)[1]
+    parts = tail.split("/")
+    if len(parts) >= 3:
+        ns = parts[0]
+        rtype = parts[1]
+        name = parts[-1]
+        return name, f"{ns}/{rtype}"
+    return "", ""
+
+
+def main(subscription_id: str, subscription_name: str) -> None:
+    environment = utils.detect_environment()
+    if not utils.is_service_available_in_environment("locks", environment):
+        sys.exit(0)
+
+    locks = collect_locks(subscription_id)
+    if not locks:
+        print("No resource locks found.")
+        return
+
+    rows = []
+    for lock in locks:
+        scope = _scope(lock)
+        res_name, res_type = _resource_name_and_type(scope)
+        rows.append({
+            "Lock Name": lock.name or "",
+            "Resource Name": res_name,
+            "Resource Type": res_type,
+            "Resource Group": _resource_group(scope),
+            "Lock Level": str(lock.level) if getattr(lock, "level", None) else "",
+            "Notes": getattr(lock, "notes", "") or "",
+            "Scope": scope,
+        })
+
+    df = pd.DataFrame(rows)
+    filename = utils.create_export_filename(subscription_name, "resource-locks", "all")
+    utils.save_dataframe_to_excel(df, filename, sheet_name="Resource Locks")
+    print(f"Exported {len(rows)} resource lock(s) → {filename}")
+    log.info("Export complete: %d locks", len(rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_id, sub_name)

--- a/scripts/resource_tags_export.py
+++ b/scripts/resource_tags_export.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Resource Tags Inventory Export"""
+
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("resource-tags-export")
+utils.log_script_start("resource_tags_export.py", "Resource Tags Inventory Export")
+
+log = utils.get_logger()
+
+
+def collect_resources(subscription_id: str) -> list:
+    client = utils.get_azure_client("resource", subscription_id)
+    log.info("Listing all resources in subscription %s", subscription_id)
+    return list(client.resources.list())
+
+
+def main(subscription_id: str, subscription_name: str) -> None:
+    environment = utils.detect_environment()
+    if not utils.is_service_available_in_environment("resource", environment):
+        sys.exit(0)
+
+    resources = collect_resources(subscription_id)
+    if not resources:
+        print("No resources found.")
+        return
+
+    coverage_rows = []
+    key_counts = defaultdict(int)
+    key_values = defaultdict(set)
+
+    for r in resources:
+        rg = r.id.split("/resourceGroups/")[1].split("/")[0] if r.id and "/resourceGroups/" in r.id else ""
+        tags = r.tags or {}
+        for k, v in tags.items():
+            key_counts[k] += 1
+            key_values[k].add(v)
+        coverage_rows.append({
+            "Resource Name": r.name,
+            "Resource Type": r.type,
+            "Resource Group": rg,
+            "Location": getattr(r, "location", "") or "",
+            "Tag Count": len(tags),
+            "Tagged": "Yes" if tags else "No",
+            "Tags": "; ".join(f"{k}={v}" for k, v in tags.items()),
+        })
+
+    key_rows = [
+        {
+            "Tag Key": k,
+            "Resource Count": key_counts[k],
+            "Distinct Values": len(key_values[k]),
+            "Sample Values": ", ".join(sorted(str(v) for v in key_values[k])[:10]),
+        }
+        for k in sorted(key_counts)
+    ]
+
+    sheets = {"Tag Coverage": pd.DataFrame(coverage_rows)}
+    if key_rows:
+        sheets["Tag Keys"] = pd.DataFrame(key_rows)
+
+    filename = utils.create_export_filename(subscription_name, "resource-tags", "all")
+    utils.save_multiple_dataframes_to_excel(sheets, filename)
+    tagged = sum(1 for row in coverage_rows if row["Tagged"] == "Yes")
+    print(f"Exported {len(coverage_rows)} resource(s), {tagged} tagged, {len(key_rows)} unique tag key(s) → {filename}")
+    log.info("Export complete: %d resources, %d tag keys", len(coverage_rows), len(key_rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_id, sub_name)

--- a/utils.py
+++ b/utils.py
@@ -369,6 +369,7 @@ _CLIENT_MAP: Dict[str, tuple] = {
     "sql": ("azure.mgmt.sql", "SqlManagementClient", True),
     "cosmosdb": ("azure.mgmt.cosmosdb", "CosmosDBManagementClient", True),
     "policy": ("azure.mgmt.resource.policy", "PolicyClient", True),
+    "locks": ("azure.mgmt.resource.locks", "ManagementLockClient", True),
     "managementgroups": ("azure.mgmt.managementgroups", "ManagementGroupsAPI", False),
     "security": ("azure.mgmt.security", "SecurityCenter", True),
     "advisor": ("azure.mgmt.advisor", "AdvisorManagementClient", True),


### PR DESCRIPTION
## Quick-win sweep — governance category

Three new exporters, **zero new SDK packages**. Adds one `_CLIENT_MAP` entry (`locks` → `ManagementLockClient`, which ships inside the already-installed `azure-mgmt-resource`). Added to the Governance menu.

| Script | Issue | Client | Notes |
|---|---|---|---|
| `resource_locks_export.py` | #43 | `locks` (new map entry) | `management_locks.list_at_subscription_level()` |
| `resource_tags_export.py` | #64 | `resource` | multi-sheet: Tag Coverage + Tag Keys distribution |
| `policy_definitions_export.py` | #63 | `policy` | `policy_definitions.list()` filtered to `Custom` |

### Deviations from issue spec (flag for testing)
- **#43 Resource Locks** — `ManagementLockObject` does not reliably expose **Created By / Created Date** (no `systemData` on the lock model), so those columns were replaced with a `Scope` column for traceability. @monkizzle: confirm whether created-by metadata is available in the live tenant; if so we can add it back.
- **#64 Tags** — required-tag / missing-tag configurability deferred (no config surface yet). Current sheets give coverage (tagged Y/N, count) and per-key value distribution.
- **#63 Policy** — `Effect` is read from `policy_rule.then.effect`; when the effect is parameterized it will show the `[parameters('...')]` reference rather than a literal.

Compile-checked locally.

**Testing:** Not yet validated against a live subscription — @monkizzle to verify post-merge.

Closes #43, #63, #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)