### PR TITLE
feat(monitoring): Diagnostic Settings cross-resource audit exporter (#1 FedRAMP gap)

### DIFF
--- a/azurescan.py
+++ b/azurescan.py
@@ -76,6 +76,7 @@ MONITORING_EXPORTERS = [
     ("Metric & Activity Log Alerts",   "metric_alerts_export.py"),
     ("Action Groups",                  "action_groups_export.py"),
     ("Log Analytics Workspaces",       "log_analytics_export.py"),
+    ("Diagnostic Settings (audit)",    "diagnostic_settings_export.py"),
 ]
 
 

--- a/scripts/diagnostic_settings_export.py
+++ b/scripts/diagnostic_settings_export.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""StratusScanCLI-Azure — Diagnostic Settings Cross-Resource Audit Export"""
+
+import sys
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent))
+    import utils
+
+import pandas as pd
+
+utils.setup_logging("diagnostic-settings-export")
+utils.log_script_start("diagnostic_settings_export.py", "Diagnostic Settings Cross-Resource Audit Export")
+
+log = utils.get_logger()
+
+
+def collect_resources(subscription_id: str) -> list:
+    client = utils.get_azure_client("resource", subscription_id)
+    log.info("Listing all resources in subscription %s", subscription_id)
+    return list(client.resources.list())
+
+
+def _enabled_log_categories(setting) -> str:
+    cats = []
+    for entry in getattr(setting, "logs", None) or []:
+        if getattr(entry, "enabled", False):
+            cats.append(getattr(entry, "category", None) or getattr(entry, "category_group", None) or "")
+    return ", ".join(c for c in cats if c)
+
+
+def _metrics_enabled(setting) -> bool:
+    return any(getattr(m, "enabled", False) for m in (getattr(setting, "metrics", None) or []))
+
+
+def _destinations(setting) -> str:
+    dests = []
+    ws = getattr(setting, "workspace_id", "") or ""
+    if ws:
+        dests.append(f"LogAnalytics:{ws.split('/')[-1]}")
+    sa = getattr(setting, "storage_account_id", "") or ""
+    if sa:
+        dests.append(f"Storage:{sa.split('/')[-1]}")
+    eh = getattr(setting, "event_hub_name", "") or getattr(setting, "event_hub_authorization_rule_id", "") or ""
+    if eh:
+        dests.append(f"EventHub:{eh.split('/')[-1]}")
+    return ", ".join(dests)
+
+
+def _max_retention(setting) -> str:
+    days = []
+    for entry in (getattr(setting, "logs", None) or []) + (getattr(setting, "metrics", None) or []):
+        policy = getattr(entry, "retention_policy", None)
+        if policy and getattr(policy, "enabled", False) and getattr(policy, "days", None):
+            days.append(policy.days)
+    return str(max(days)) if days else ""
+
+
+def main(subscription_id: str, subscription_name: str) -> None:
+    environment = utils.detect_environment()
+    if not utils.is_service_available_in_environment("monitor", environment):
+        sys.exit(0)
+
+    resources = collect_resources(subscription_id)
+    if not resources:
+        print("No resources found.")
+        return
+
+    monitor = utils.get_azure_client("monitor", subscription_id)
+    log.info("Auditing diagnostic settings across %d resources (one API call each)", len(resources))
+
+    summary_rows = []
+    detail_rows = []
+
+    for r in resources:
+        rg = r.id.split("/resourceGroups/")[1].split("/")[0] if r.id and "/resourceGroups/" in r.id else ""
+        try:
+            settings = list(monitor.diagnostic_settings.list(r.id).value or [])
+            status = "Yes" if settings else "No"
+        except Exception:
+            settings = []
+            status = "Unsupported/Error"
+
+        summary_rows.append({
+            "Resource Name": r.name,
+            "Resource Type": r.type,
+            "Resource Group": rg,
+            "Has Diagnostics": status,
+            "Setting Count": len(settings),
+        })
+
+        for s in settings:
+            detail_rows.append({
+                "Resource Name": r.name,
+                "Resource Type": r.type,
+                "Resource Group": rg,
+                "Setting Name": getattr(s, "name", "") or "",
+                "Log Categories": _enabled_log_categories(s),
+                "Metrics Enabled": "Yes" if _metrics_enabled(s) else "No",
+                "Destination": _destinations(s),
+                "Retention Days": _max_retention(s),
+            })
+
+    sheets = {"Summary": pd.DataFrame(summary_rows)}
+    if detail_rows:
+        sheets["Diagnostic Settings"] = pd.DataFrame(detail_rows)
+
+    filename = utils.create_export_filename(subscription_name, "diagnostic-settings", "all")
+    utils.save_multiple_dataframes_to_excel(sheets, filename)
+
+    enabled = sum(1 for row in summary_rows if row["Has Diagnostics"] == "Yes")
+    print(f"Audited {len(summary_rows)} resource(s): {enabled} with diagnostics, {len(detail_rows)} setting(s) → {filename}")
+    log.info("Export complete: %d resources audited, %d settings", len(summary_rows), len(detail_rows))
+
+
+if __name__ == "__main__":
+    cfg = utils.get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    sub_name = utils.get_subscription_name(sub_id)
+    if not sub_id:
+        print("ERROR: No subscription configured. Run configure.py first.")
+        sys.exit(1)
+    main(sub_id, sub_name)


### PR DESCRIPTION
## Quick-win sweep — monitoring category (flagship)

The single highest-value missing exporter: per-resource diagnostic settings audit — the **#1 FedRAMP AU-control gap**. Uses `MonitorManagementClient` + `ResourceManagementClient` (both in `_CLIENT_MAP`) — **zero new SDK dependencies**. Added to the Monitoring menu.

| Script | Issue | Notes |
|---|---|---|
| `diagnostic_settings_export.py` | #37 | iterates all resources, `diagnostic_settings.list(resource_id)` per resource |

### Behavior notes for testing
- **Heaviest exporter** — makes one `diagnostic_settings.list()` call per resource in the subscription. On large subscriptions this is slow and chatty. A Resource Graph–based optimization is a natural v0.2.0 follow-up.
- Resource types that don't support diagnostic settings raise on the call; these are caught and marked **`Unsupported/Error`** in the summary rather than aborting the run.
- Multi-sheet output: **Summary** (resource → Has Diagnostics Y/N/Unsupported, setting count) + **Diagnostic Settings** (flattened detail: log categories, metrics enabled, destination, retention days).
- Destination column collapses Log Analytics / Storage / Event Hub targets to their resource names.

Compile-checked locally.

**Testing:** Not yet validated against a live subscription — @monkizzle to verify, especially the per-resource-type support handling and the destination/retention parsing.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)