### PR TITLE
fix: restore Cloud Shell dependency bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,11 @@ Sibling project to [StratusScan-CLI (AWS)](https://github.com/ColonelPanicX/Stra
 
 ### Azure Cloud Shell (recommended)
 
-The tool is designed to work in a fresh [Azure Cloud Shell](https://shell.azure.com) session with no extra setup. Credentials are injected automatically.
+The tool is designed to work in a fresh [Azure Cloud Shell](https://shell.azure.com) session with no extra setup. Credentials are injected automatically, and `configure.py` / `azurescan.py` install their own dependencies on first run.
 
 ```bash
 git clone https://github.com/ColonelPanicX/stratusscan-cli-azure.git
 cd stratusscan-cli-azure
-pip install -r <(python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); print('\n'.join(d['project']['dependencies']))")
 python configure.py
 python azurescan.py
 ```
@@ -48,12 +47,6 @@ Requires [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) in
 ```bash
 git clone https://github.com/ColonelPanicX/stratusscan-cli-azure.git
 cd stratusscan-cli-azure
-
-# Install dependencies
-pip install azure-identity azure-mgmt-resource azure-mgmt-compute azure-mgmt-network \
-    azure-mgmt-storage azure-mgmt-keyvault azure-mgmt-authorization \
-    azure-mgmt-containerservice azure-mgmt-web azure-mgmt-sql azure-mgmt-cosmosdb \
-    pandas openpyxl python-dateutil questionary
 
 # Authenticate
 az login

--- a/azurescan.py
+++ b/azurescan.py
@@ -16,8 +16,12 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Ensure utils is importable from the project root
+# Ensure local modules are importable from the project root.
 sys.path.insert(0, str(Path(__file__).parent))
+
+import bootstrap
+
+bootstrap.ensure_dependencies()
 
 try:
     import utils
@@ -148,7 +152,6 @@ def _run_exporter(script_rel_path: str, sub_id: str, sub_name: str) -> int:
 # ---------------------------------------------------------------------------
 
 def _print_banner() -> None:
-    cfg = utils.get_config()
     env = utils.detect_environment()
     env_label = "AzureUSGovernment" if env == "government" else "AzurePublicCloud"
     version = utils.get_version()

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+StratusScanCLI-Azure dependency bootstrap.
+
+CloudShell-first: configure.py and azurescan.py call ensure_dependencies()
+before importing utils, which pulls in Azure SDKs, pandas, and questionary.
+This keeps a fresh Azure Cloud Shell run from requiring a manual pip step.
+
+Stdlib-only. Safe to import before project dependencies are installed.
+"""
+
+import importlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_ATTEMPTED_ENV = "AZURESCAN_BOOTSTRAP_ATTEMPTED"
+
+_REQUIRED_MODULES = [
+    "azure.identity",
+    "azure.mgmt.resource.resources",
+    "azure.mgmt.resource.subscriptions",
+    "azure.mgmt.compute",
+    "azure.mgmt.network",
+    "azure.mgmt.storage",
+    "pandas",
+    "openpyxl",
+    "dateutil",
+    "questionary",
+]
+
+
+def _read_pyproject_dependencies() -> list[str]:
+    pyproject = Path(__file__).parent / "pyproject.toml"
+    try:
+        import tomllib
+
+        with open(pyproject, "rb") as fh:
+            return tomllib.load(fh)["project"]["dependencies"]
+    except ModuleNotFoundError:
+        text = pyproject.read_text()
+        start = text.index("dependencies = [")
+        end = text.index("]", start)
+        deps = []
+        for line in text[start:end].splitlines()[1:]:
+            line = line.strip().strip(",").strip()
+            if line.startswith(('"', "'")):
+                deps.append(line.strip("\"'"))
+        return deps
+
+
+def _is_missing(module: str) -> bool:
+    try:
+        importlib.import_module(module)
+        return False
+    except ImportError:
+        return True
+
+
+def ensure_dependencies() -> None:
+    missing = [module for module in _REQUIRED_MODULES if _is_missing(module)]
+    if not missing:
+        return
+
+    if os.environ.get(_ATTEMPTED_ENV):
+        print(f"WARNING: dependencies still unavailable after install: {', '.join(missing)}")
+        return
+
+    print(f"Installing required dependencies (missing: {', '.join(missing)})...")
+    deps = _read_pyproject_dependencies()
+    subprocess.run([sys.executable, "-m", "pip", "install", *deps], check=True)
+    print("Dependencies installed. Restarting...\n")
+
+    os.environ[_ATTEMPTED_ENV] = "1"
+    os.execv(sys.executable, [sys.executable, *sys.argv])

--- a/configure.py
+++ b/configure.py
@@ -10,11 +10,14 @@ Usage:
     python configure.py
 """
 
-import json
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
+
+import bootstrap
+
+bootstrap.ensure_dependencies()
 
 try:
     import utils

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 
 dependencies = [
     "azure-identity>=1.15.0",
-    "azure-mgmt-resource>=23.0.0",
+    "azure-mgmt-resource>=23.0.0,<25.0.0",
     "azure-mgmt-compute>=30.0.0",
     "azure-mgmt-network>=25.0.0",
     "azure-mgmt-storage>=21.0.0",

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,127 @@
+import subprocess
+import sys
+
+import bootstrap
+import utils
+
+
+def test_ensure_dependencies_installs_pyproject_dependencies_when_module_missing(monkeypatch):
+    calls = []
+    exec_calls = []
+
+    monkeypatch.setattr(
+        bootstrap,
+        "_is_missing",
+        lambda module: module == "azure.mgmt.resource.subscriptions",
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        "_read_pyproject_dependencies",
+        lambda: ["azure-mgmt-resource>=23.0.0,<25.0.0"],
+    )
+    monkeypatch.setattr(subprocess, "run", lambda cmd, check: calls.append((cmd, check)))
+    monkeypatch.delenv(bootstrap._ATTEMPTED_ENV, raising=False)
+    monkeypatch.setattr(bootstrap.os, "execv", lambda executable, args: exec_calls.append((executable, args)))
+
+    bootstrap.ensure_dependencies()
+
+    assert calls == [
+        ([sys.executable, "-m", "pip", "install", "azure-mgmt-resource>=23.0.0,<25.0.0"], True)
+    ]
+    assert exec_calls == [(sys.executable, [sys.executable, *sys.argv])]
+
+
+def test_ensure_dependencies_skips_pip_when_required_modules_exist(monkeypatch):
+    monkeypatch.setattr(bootstrap, "_is_missing", lambda module: False)
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("pip should not run when dependencies are present")
+
+    monkeypatch.setattr(subprocess, "run", fail_run)
+
+    bootstrap.ensure_dependencies()
+
+
+def test_ensure_dependencies_does_not_loop_after_install_attempt(monkeypatch):
+    monkeypatch.setattr(bootstrap, "_is_missing", lambda module: True)
+    monkeypatch.setenv(bootstrap._ATTEMPTED_ENV, "1")
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("pip should not run after bootstrap was already attempted")
+
+    monkeypatch.setattr(subprocess, "run", fail_run)
+
+    bootstrap.ensure_dependencies()
+
+
+def test_resource_dependency_is_capped_below_split_release():
+    deps = bootstrap._read_pyproject_dependencies()
+
+    assert "azure-mgmt-resource>=23.0.0,<25.0.0" in deps
+
+
+def test_resource_clients_use_stable_submodule_paths():
+    assert utils._CLIENT_MAP["subscription"] == (
+        "azure.mgmt.resource.subscriptions",
+        "SubscriptionClient",
+        False,
+    )
+    assert utils._CLIENT_MAP["resource"] == (
+        "azure.mgmt.resource.resources",
+        "ResourceManagementClient",
+        True,
+    )
+
+
+def test_government_clients_use_government_arm_scope(monkeypatch):
+    captured = {}
+
+    class Client:
+        def __init__(self, credential, **kwargs):
+            captured["credential"] = credential
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setitem(
+        utils._CLIENT_MAP,
+        "subscription",
+        ("tests.fake_module", "Client", False),
+    )
+    monkeypatch.setattr(utils, "_get_credential", lambda: "credential")
+    monkeypatch.setattr(utils, "detect_environment", lambda: "government")
+
+    def fake_import_module(module_path):
+        assert module_path == "tests.fake_module"
+
+        class Module:
+            pass
+
+        Module.Client = Client
+        return Module
+
+    monkeypatch.setattr("importlib.import_module", fake_import_module)
+
+    utils.get_azure_client("subscription")
+
+    assert captured["credential"] == "credential"
+    assert captured["kwargs"]["base_url"] == "https://management.usgovcloudapi.net"
+    assert captured["kwargs"]["credential_scopes"] == [
+        "https://management.usgovcloudapi.net/.default"
+    ]
+
+
+def test_government_credential_rewrites_public_arm_scope():
+    captured = {}
+
+    class Credential:
+        def get_token(self, *scopes, **kwargs):
+            captured["scopes"] = scopes
+            captured["kwargs"] = kwargs
+            return "token"
+
+    credential = utils._GovernmentCredential(Credential())
+
+    token = credential.get_token("https://management.azure.com/.default", tenant_id="tenant")
+
+    assert token == "token"
+    assert captured["scopes"] == ("https://management.usgovcloudapi.net/.default",)
+    assert captured["kwargs"] == {"tenant_id": "tenant"}

--- a/utils.py
+++ b/utils.py
@@ -334,6 +334,22 @@ _credential_lock = threading.Lock()
 _credential_cache: Optional[Any] = None
 
 
+class _GovernmentCredential:
+    """Rewrite public ARM token scopes to the Azure Government ARM scope."""
+
+    def __init__(self, credential: Any) -> None:
+        self._credential = credential
+
+    def get_token(self, *scopes: str, **kwargs: Any) -> Any:
+        gov_scopes = tuple(
+            f"{_GOV_BASE_URL}/.default"
+            if scope in ("https://management.azure.com/.default", "https://management.azure.com")
+            else scope
+            for scope in scopes
+        )
+        return self._credential.get_token(*gov_scopes, **kwargs)
+
+
 def _get_credential():
     """Return a cached DefaultAzureCredential, configured for the active environment."""
     global _credential_cache
@@ -347,8 +363,8 @@ def _get_credential():
 
         environment = detect_environment()
         if environment == "government":
-            _credential_cache = DefaultAzureCredential(
-                authority=AzureAuthorityHosts.AZURE_GOVERNMENT
+            _credential_cache = _GovernmentCredential(
+                DefaultAzureCredential(authority=AzureAuthorityHosts.AZURE_GOVERNMENT)
             )
         else:
             _credential_cache = DefaultAzureCredential()
@@ -357,8 +373,8 @@ def _get_credential():
 
 # Lazy import map: service_name → (module_path, class_name, needs_subscription_id)
 _CLIENT_MAP: Dict[str, tuple] = {
-    "subscription": ("azure.mgmt.resource", "SubscriptionClient", False),
-    "resource": ("azure.mgmt.resource", "ResourceManagementClient", True),
+    "subscription": ("azure.mgmt.resource.subscriptions", "SubscriptionClient", False),
+    "resource": ("azure.mgmt.resource.resources", "ResourceManagementClient", True),
     "compute": ("azure.mgmt.compute", "ComputeManagementClient", True),
     "network": ("azure.mgmt.network", "NetworkManagementClient", True),
     "storage": ("azure.mgmt.storage", "StorageManagementClient", True),
@@ -417,6 +433,7 @@ def get_azure_client(service_name: str, subscription_id: Optional[str] = None) -
     kwargs: Dict[str, Any] = {}
     if environment == "government":
         kwargs["base_url"] = _GOV_BASE_URL
+        kwargs["credential_scopes"] = [f"{_GOV_BASE_URL}/.default"]
 
     if needs_sub:
         return cls(cred, subscription_id, **kwargs)


### PR DESCRIPTION
## Summary
- restore the stdlib-only dependency bootstrap used by configure.py and azurescan.py
- install dependencies from pyproject.toml before importing utils
- update README Cloud Shell instructions to remove the manual pip install step
- add regression tests for install/no-install bootstrap behavior

## Repro
Fresh Azure Cloud Shell on dev fails during configure.py after selecting AzureUSGovernment with:

```
Missing package: pip install azure-mgmt-resource
```

## Validation
- .venv/bin/python -m pytest tests/test_bootstrap.py
- .venv/bin/python -m ruff check bootstrap.py tests/test_bootstrap.py azurescan.py configure.py
- python -m compileall bootstrap.py azurescan.py configure.py