### PR TITLE
feat(network): flatten NSG security rules to a second sheet (SSAZR-031)

### DIFF
--- a/scripts/network_security_groups_export.py
+++ b/scripts/network_security_groups_export.py
@@ -24,6 +24,52 @@ def collect_nsgs(subscription_id: str) -> list:
     return list(client.network_security_groups.list_all())
 
 
+def _join(items) -> str:
+    if not items:
+        return ""
+    return ", ".join(str(i) for i in items)
+
+
+def _values(singular, plural) -> str:
+    if plural:
+        return _join(plural)
+    return str(singular) if singular else ""
+
+
+def _flatten_rules(nsg) -> list:
+    rg = utils.extract_resource_group(nsg.id)
+    rule_groups = (
+        ("Custom", nsg.security_rules or []),
+        ("Default", nsg.default_security_rules or []),
+    )
+    rows = []
+    for rule_type, rules in rule_groups:
+        for rule in rules:
+            rows.append({
+                "NSG Name": nsg.name,
+                "Resource Group": rg,
+                "Location": nsg.location,
+                "Rule Name": rule.name,
+                "Rule Type": rule_type,
+                "Priority": rule.priority,
+                "Direction": str(rule.direction or ""),
+                "Access": str(rule.access or ""),
+                "Protocol": str(rule.protocol or ""),
+                "Source Ports": _values(rule.source_port_range, rule.source_port_ranges),
+                "Destination Ports": _values(
+                    rule.destination_port_range, rule.destination_port_ranges
+                ),
+                "Source Addresses": _values(
+                    rule.source_address_prefix, rule.source_address_prefixes
+                ),
+                "Destination Addresses": _values(
+                    rule.destination_address_prefix, rule.destination_address_prefixes
+                ),
+                "Description": rule.description or "",
+            })
+    return rows
+
+
 def main(subscription_id: str, subscription_name: str) -> None:
     environment = utils.detect_environment()
     if not utils.is_service_available_in_environment("network", environment):
@@ -35,12 +81,11 @@ def main(subscription_id: str, subscription_name: str) -> None:
         return
 
     rows = []
+    rule_rows = []
     for nsg in nsgs:
         rg = utils.extract_resource_group(nsg.id)
         tags = nsg.tags or {}
-        inbound = len(nsg.security_rules or [])
         default_inbound = len(nsg.default_security_rules or [])
-        # Count rules by direction
         inbound_rules = sum(
             1 for r in (nsg.security_rules or [])
             if r.direction and str(r.direction).lower() == "inbound"
@@ -63,12 +108,16 @@ def main(subscription_id: str, subscription_name: str) -> None:
             "Provisioning State": nsg.provisioning_state or "",
             "Tags": "; ".join(f"{k}={v}" for k, v in tags.items()),
         })
+        rule_rows.extend(_flatten_rules(nsg))
 
-    df = pd.DataFrame(rows)
+    summary_df = pd.DataFrame(rows)
+    rules_df = pd.DataFrame(rule_rows)
     filename = utils.create_export_filename(subscription_name, "network-security-groups", "all")
-    utils.save_dataframe_to_excel(df, filename, sheet_name="NSGs")
-    print(f"Exported {len(rows)} NSG(s) → {filename}")
-    log.info("Export complete: %d NSGs", len(rows))
+    utils.save_multiple_dataframes_to_excel(
+        {"NSGs": summary_df, "Rules": rules_df}, filename
+    )
+    print(f"Exported {len(rows)} NSG(s) and {len(rule_rows)} rule(s) → {filename}")
+    log.info("Export complete: %d NSGs, %d flattened rules", len(rows), len(rule_rows))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## SSAZR-031 — NSG rule flatten (GH #31)

Adds a **"Rules"** sheet to the NSG exporter alongside the existing **"NSGs"** summary. One row per security rule across every NSG — **custom and default** — giving auditors a flat, sortable view of effective NSG rules instead of just per-NSG counts.

### Columns
NSG Name · Resource Group · Location · Rule Name · Rule Type (Custom/Default) · Priority · Direction · Access · Protocol · Source Ports · Destination Ports · Source Addresses · Destination Addresses · Description

### Notes
- **No extra API call** — rules are already embedded in the `NetworkManagementClient.network_security_groups.list_all()` result.
- `_values()` collapses the singular-vs-plural `SecurityRule` fields (`source_port_range` ↔ `source_port_ranges`, address prefixes likewise).
- Writer switched to `save_multiple_dataframes_to_excel({"NSGs":…, "Rules":…})`.
- Dropped a pre-existing dead local (`inbound`).

### Verification
- `py_compile` clean.
- Logic exercised with mock NSG objects: custom + default rules flatten correctly; singular `*`/`22` and plural `["80","443"]` port/address forms both render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)