### PR TITLE
feat: rename to stratusscan, auto-detect cloud, fix multi-subscription scanning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,16 +18,16 @@ Must work in a fresh Azure Cloud Shell session with no extra setup beyond `pip i
 If a proposed change breaks this, reject it.
 
 ### 2. subprocess architecture
-`azurescan.py` launches exporters as subprocesses. It never calls Azure APIs directly.
+`stratusscan.py` launches exporters as subprocesses. It never calls Azure APIs directly.
 Exporters in `scripts/` are fully independent — they can also run directly.
 
 ### 3. No print() in utils.py
 `utils.py` is a shared library. It must not emit console output. Return structured data.
-Only the CLI scripts (azurescan.py, configure.py, exporter scripts) print to console.
+Only the CLI scripts (stratusscan.py, configure.py, exporter scripts) print to console.
 
 ### 4. CI mode
-`AZURESCAN_AUTO_RUN=1` bypasses all interactive prompts.
-`AZURESCAN_SUBSCRIPTIONS=sub-id-1,sub-id-2` sets subscriptions non-interactively.
+`STRATUSSCAN_AUTO_RUN=1` bypasses all interactive prompts.
+`STRATUSSCAN_SUBSCRIPTIONS=sub-id-1,sub-id-2` sets subscriptions non-interactively.
 Every interactive prompt must check `utils.is_auto_run()` before displaying.
 
 ### 5. TUI-ready design
@@ -39,7 +39,7 @@ No arbitrary prints in shared code.
 ## Project Structure
 
 ```
-azurescan.py              # main menu — launches exporters as subprocesses
+stratusscan.py              # main menu — launches exporters as subprocesses
 configure.py              # subscription/environment config wizard
 utils.py                  # shared library — imported by every exporter
 scripts/                  # all exporters — flat directory, no subdirs
@@ -134,7 +134,7 @@ Azure SDK `.list()` methods return lazy iterators — wrap in `list()` to materi
 | `save_multiple_dataframes_to_excel(sheets, filename)` | Multi-sheet write |
 | `get_config()` | Thread-safe config.json singleton |
 | `is_auto_run()` | CI mode check |
-| `get_auto_subscriptions()` | Reads AZURESCAN_SUBSCRIPTIONS env var |
+| `get_auto_subscriptions()` | Reads STRATUSSCAN_SUBSCRIPTIONS env var |
 | `list_subscriptions()` | Lists all accessible subscriptions |
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,7 +195,7 @@ if __name__ == "__main__":
 
 All exporter scripts live in `scripts/` (flat directory, no subdirs). Name the file `{resource_type}_export.py`.
 
-After adding the script, register it in `azurescan.py` under the appropriate tier (`TIER1_EXPORTERS`, `TIER2_EXPORTERS`, `GOVERNANCE_EXPORTERS`, or `MONITORING_EXPORTERS`).
+After adding the script, register it in `stratusscan.py` under the appropriate tier (`TIER1_EXPORTERS`, `TIER2_EXPORTERS`, `GOVERNANCE_EXPORTERS`, or `MONITORING_EXPORTERS`).
 
 ---
 
@@ -222,9 +222,9 @@ These are non-negotiable and apply to all contributions:
 
 **Minimal dependencies** — stick to `azure-identity`, `azure-mgmt-*` (per service), `pandas`, `openpyxl`, `python-dateutil`, `questionary`. No heavy frameworks. No lockfiles. No build tools.
 
-**Subprocess architecture** — `azurescan.py` launches exporters as subprocesses. It never calls Azure APIs directly. Don't break this boundary.
+**Subprocess architecture** — `stratusscan.py` launches exporters as subprocesses. It never calls Azure APIs directly. Don't break this boundary.
 
-**CI mode** — every interactive prompt must check `utils.is_auto_run()` before displaying. `AZURESCAN_AUTO_RUN=1` must bypass all prompts.
+**CI mode** — every interactive prompt must check `utils.is_auto_run()` before displaying. `STRATUSSCAN_AUTO_RUN=1` must bypass all prompts.
 
 **No print() in utils.py** — `utils.py` is a shared library. Functions return structured results. Only CLI scripts print.
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ Sibling project to [StratusScan-CLI (AWS)](https://github.com/ColonelPanicX/Stra
 
 ### Azure Cloud Shell (recommended)
 
-The tool is designed to work in a fresh [Azure Cloud Shell](https://shell.azure.com) session with no extra setup. Credentials are injected automatically, and `configure.py` / `azurescan.py` install their own dependencies on first run.
+The tool is designed to work in a fresh [Azure Cloud Shell](https://shell.azure.com) session with no extra setup. Credentials are injected automatically, and `configure.py` / `stratusscan.py` install their own dependencies on first run.
 
 ```bash
 git clone https://github.com/ColonelPanicX/stratusscan-cli-azure.git
 cd stratusscan-cli-azure
 python configure.py
-python azurescan.py
+python stratusscan.py
 ```
 
 ### Local Machine
@@ -54,16 +54,16 @@ az login
 # Configure subscription and environment
 python configure.py
 
-# Launch AzureScan
-python azurescan.py
+# Launch StratusScan
+python stratusscan.py
 ```
 
 ### pip install (once published)
 
 ```bash
 pip install stratusscan-cli-azure
-azurescan-configure
-azurescan
+stratusscan-configure
+stratusscan
 ```
 
 > **Note:** PyPI publishing is pending the first stable release.
@@ -127,13 +127,13 @@ export AZURE_ENVIRONMENT=AzureUSGovernment
 ### CI / Unattended execution
 
 ```bash
-AZURESCAN_AUTO_RUN=1 AZURESCAN_SUBSCRIPTIONS=sub-id-1,sub-id-2 python azurescan.py
+STRATUSSCAN_AUTO_RUN=1 STRATUSSCAN_SUBSCRIPTIONS=sub-id-1,sub-id-2 python stratusscan.py
 ```
 
 Individual exporters also support CI mode:
 
 ```bash
-AZURESCAN_AUTO_RUN=1 python scripts/virtual_machines_export.py
+STRATUSSCAN_AUTO_RUN=1 python scripts/virtual_machines_export.py
 ```
 
 ---
@@ -143,7 +143,7 @@ AZURESCAN_AUTO_RUN=1 python scripts/virtual_machines_export.py
 ### Main menu
 
 ```bash
-python azurescan.py
+python stratusscan.py
 ```
 
 Select **Tier 1** or **Tier 2** from the menu, then pick an individual exporter or run all. Exports are saved to `output/` as `.xlsx` files.

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -2,7 +2,7 @@
 """
 StratusScanCLI-Azure dependency bootstrap.
 
-CloudShell-first: configure.py and azurescan.py call ensure_dependencies()
+CloudShell-first: configure.py and stratusscan.py call ensure_dependencies()
 before importing utils, which pulls in Azure SDKs, pandas, and questionary.
 This keeps a fresh Azure Cloud Shell run from requiring a manual pip step.
 
@@ -15,7 +15,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-_ATTEMPTED_ENV = "AZURESCAN_BOOTSTRAP_ATTEMPTED"
+_ATTEMPTED_ENV = "STRATUSSCAN_BOOTSTRAP_ATTEMPTED"
 
 _REQUIRED_MODULES = [
     "azure.identity",

--- a/configure.py
+++ b/configure.py
@@ -4,7 +4,7 @@ StratusScanCLI-Azure — Configuration Wizard
 Version: v0.1.0
 
 Handles subscription discovery and selection, environment configuration,
-and writes config.json for use by azurescan.py and all exporter scripts.
+and writes config.json for use by stratusscan.py and all exporter scripts.
 
 Usage:
     python configure.py
@@ -27,7 +27,7 @@ except ImportError:
     sys.exit(1)
 
 utils.setup_logging("configure", log_to_file=True)
-utils.log_script_start("configure.py", "AzureScan Configuration Wizard")
+utils.log_script_start("configure.py", "StratusScan Configuration Wizard")
 
 log = utils.get_logger()
 
@@ -144,7 +144,7 @@ def _print_summary(config: dict) -> None:
     print(f"  Default subscription: {config['default_subscription_id']}")
     print(f"  Subscriptions:        {len(config['subscriptions'])}")
     print()
-    print("  Run azurescan.py to start exporting.")
+    print("  Run stratusscan.py to start exporting.")
     print("=" * 64 + "\n")
 
 

--- a/configure.py
+++ b/configure.py
@@ -41,12 +41,21 @@ def select_environment() -> str:
     print("  AZURE ENVIRONMENT SELECTION")
     print("=" * 64)
     print("  Select the Azure cloud environment for your credentials.")
+
+    detected = utils.detect_azure_cloud()
+    if detected:
+        detected_label = "AzureUSGovernment" if detected == "government" else "AzurePublicCloud"
+        print(f"  Detected active Azure CLI cloud: {detected_label}")
     print()
 
-    options = [
-        "AzurePublicCloud   (commercial — portal.azure.com)",
-        "AzureUSGovernment  (FedRAMP/government — portal.azure.us)",
-    ]
+    public_label = "AzurePublicCloud   (commercial — portal.azure.com)"
+    gov_label = "AzureUSGovernment  (FedRAMP/government — portal.azure.us)"
+    if detected == "government":
+        gov_label += "   [detected]"
+    elif detected == "public":
+        public_label += "   [detected]"
+
+    options = [public_label, gov_label]
     choice = utils.prompt_menu("ENVIRONMENT", options, allow_back=False, allow_exit=True)
     if choice == "exit":
         sys.exit(0)

--- a/docs/stratusscan-philosophy.md
+++ b/docs/stratusscan-philosophy.md
@@ -123,7 +123,7 @@ Scope name (account name / subscription name) in filenames comes from config map
 Environment variables suppress interactive prompts for CI/CD:
 - `{CSP}SCAN_AUTO_RUN=1` — bypass all interactive prompts
 - AWS: `STRATUSSCAN_REGIONS=us-east-1,us-west-2`
-- Azure: `AZURESCAN_SUBSCRIPTIONS=sub-id-1,sub-id-2`
+- Azure: `STRATUSSCAN_SUBSCRIPTIONS=sub-id-1,sub-id-2`
 
 CLI flags (v0.2.0+): `--version`, `--dry-run`, `--verbose`, `--help`. When no flags are passed, fall through to the interactive menu.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,14 +99,14 @@ dev = [
 ]
 
 [project.scripts]
-azurescan = "azurescan:main"
-azurescan-configure = "configure:main"
+stratusscan = "stratusscan:main"
+stratusscan-configure = "configure:main"
 
 [project.urls]
 Repository = "https://github.com/ColonelPanicX/StratusScan-CLI-Azure"
 
 [tool.setuptools]
-py-modules = ["azurescan", "configure", "utils"]
+py-modules = ["stratusscan", "configure", "utils"]
 include-package-data = true
 
 [tool.setuptools.package-data]

--- a/scripts/action_groups_export.py
+++ b/scripts/action_groups_export.py
@@ -97,9 +97,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/advisor_export.py
+++ b/scripts/advisor_export.py
@@ -100,9 +100,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/aks_clusters_export.py
+++ b/scripts/aks_clusters_export.py
@@ -69,9 +69,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/api_management_export.py
+++ b/scripts/api_management_export.py
@@ -60,9 +60,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/app_service_export.py
+++ b/scripts/app_service_export.py
@@ -71,9 +71,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/application_gateway_export.py
+++ b/scripts/application_gateway_export.py
@@ -69,9 +69,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/application_insights_export.py
+++ b/scripts/application_insights_export.py
@@ -66,9 +66,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/automation_accounts_export.py
+++ b/scripts/automation_accounts_export.py
@@ -57,9 +57,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/availability_sets_export.py
+++ b/scripts/availability_sets_export.py
@@ -76,9 +76,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/azure_firewall_export.py
+++ b/scripts/azure_firewall_export.py
@@ -64,9 +64,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/azure_sql_export.py
+++ b/scripts/azure_sql_export.py
@@ -72,9 +72,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/bastion_hosts_export.py
+++ b/scripts/bastion_hosts_export.py
@@ -84,9 +84,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/batch_accounts_export.py
+++ b/scripts/batch_accounts_export.py
@@ -58,9 +58,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/blob_containers_export.py
+++ b/scripts/blob_containers_export.py
@@ -64,9 +64,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/container_apps_export.py
+++ b/scripts/container_apps_export.py
@@ -70,9 +70,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/container_instances_export.py
+++ b/scripts/container_instances_export.py
@@ -82,9 +82,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/container_registry_export.py
+++ b/scripts/container_registry_export.py
@@ -62,9 +62,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/cosmos_db_export.py
+++ b/scripts/cosmos_db_export.py
@@ -68,9 +68,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/cost_management_export.py
+++ b/scripts/cost_management_export.py
@@ -67,9 +67,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/ddos_protection_export.py
+++ b/scripts/ddos_protection_export.py
@@ -57,9 +57,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/defender_assessments_export.py
+++ b/scripts/defender_assessments_export.py
@@ -104,9 +104,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/defender_scores_export.py
+++ b/scripts/defender_scores_export.py
@@ -97,9 +97,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/diagnostic_settings_export.py
+++ b/scripts/diagnostic_settings_export.py
@@ -117,9 +117,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/dns_zones_export.py
+++ b/scripts/dns_zones_export.py
@@ -88,9 +88,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/event_hubs_export.py
+++ b/scripts/event_hubs_export.py
@@ -62,9 +62,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/expressroute_export.py
+++ b/scripts/expressroute_export.py
@@ -63,9 +63,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/file_shares_export.py
+++ b/scripts/file_shares_export.py
@@ -62,9 +62,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/firewall_policy_rules_export.py
+++ b/scripts/firewall_policy_rules_export.py
@@ -178,9 +178,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/front_door_export.py
+++ b/scripts/front_door_export.py
@@ -58,9 +58,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/function_apps_export.py
+++ b/scripts/function_apps_export.py
@@ -69,9 +69,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/key_vault_export.py
+++ b/scripts/key_vault_export.py
@@ -73,9 +73,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/key_vault_objects_export.py
+++ b/scripts/key_vault_objects_export.py
@@ -167,9 +167,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/load_balancers_export.py
+++ b/scripts/load_balancers_export.py
@@ -63,9 +63,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/log_analytics_export.py
+++ b/scripts/log_analytics_export.py
@@ -84,9 +84,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/logic_apps_export.py
+++ b/scripts/logic_apps_export.py
@@ -58,9 +58,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/managed_disks_export.py
+++ b/scripts/managed_disks_export.py
@@ -80,9 +80,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/managed_identities_export.py
+++ b/scripts/managed_identities_export.py
@@ -55,9 +55,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/management_groups_export.py
+++ b/scripts/management_groups_export.py
@@ -103,9 +103,7 @@ def main(subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/metric_alerts_export.py
+++ b/scripts/metric_alerts_export.py
@@ -148,9 +148,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/mysql_flexible_export.py
+++ b/scripts/mysql_flexible_export.py
@@ -68,9 +68,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/nat_gateways_export.py
+++ b/scripts/nat_gateways_export.py
@@ -68,9 +68,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/network_security_groups_export.py
+++ b/scripts/network_security_groups_export.py
@@ -121,9 +121,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/network_watchers_export.py
+++ b/scripts/network_watchers_export.py
@@ -54,9 +54,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/policy_assignments_export.py
+++ b/scripts/policy_assignments_export.py
@@ -178,9 +178,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/policy_compliance_export.py
+++ b/scripts/policy_compliance_export.py
@@ -79,9 +79,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/policy_definitions_export.py
+++ b/scripts/policy_definitions_export.py
@@ -75,9 +75,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/postgresql_flexible_export.py
+++ b/scripts/postgresql_flexible_export.py
@@ -68,9 +68,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/private_endpoints_export.py
+++ b/scripts/private_endpoints_export.py
@@ -101,9 +101,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/public_ips_export.py
+++ b/scripts/public_ips_export.py
@@ -85,9 +85,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/recovery_services_vaults_export.py
+++ b/scripts/recovery_services_vaults_export.py
@@ -58,9 +58,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/redis_cache_export.py
+++ b/scripts/redis_cache_export.py
@@ -64,9 +64,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/resource_groups_export.py
+++ b/scripts/resource_groups_export.py
@@ -52,9 +52,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/resource_locks_export.py
+++ b/scripts/resource_locks_export.py
@@ -81,9 +81,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/resource_tags_export.py
+++ b/scripts/resource_tags_export.py
@@ -77,9 +77,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/role_assignments_export.py
+++ b/scripts/role_assignments_export.py
@@ -78,9 +78,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/route_tables_export.py
+++ b/scripts/route_tables_export.py
@@ -59,9 +59,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/service_bus_export.py
+++ b/scripts/service_bus_export.py
@@ -60,9 +60,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/service_endpoints_export.py
+++ b/scripts/service_endpoints_export.py
@@ -57,9 +57,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/snapshots_export.py
+++ b/scripts/snapshots_export.py
@@ -88,9 +88,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/sql_managed_instance_export.py
+++ b/scripts/sql_managed_instance_export.py
@@ -66,9 +66,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/storage_accounts_export.py
+++ b/scripts/storage_accounts_export.py
@@ -66,9 +66,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/subnets_export.py
+++ b/scripts/subnets_export.py
@@ -63,9 +63,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/traffic_manager_export.py
+++ b/scripts/traffic_manager_export.py
@@ -61,9 +61,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/virtual_machines_export.py
+++ b/scripts/virtual_machines_export.py
@@ -87,9 +87,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/virtual_networks_export.py
+++ b/scripts/virtual_networks_export.py
@@ -64,9 +64,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/virtual_wan_export.py
+++ b/scripts/virtual_wan_export.py
@@ -85,9 +85,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/vmss_export.py
+++ b/scripts/vmss_export.py
@@ -88,9 +88,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/vnet_peerings_export.py
+++ b/scripts/vnet_peerings_export.py
@@ -67,9 +67,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/scripts/vpn_gateways_export.py
+++ b/scripts/vpn_gateways_export.py
@@ -88,9 +88,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
 
 
 if __name__ == "__main__":
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    sub_name = utils.get_subscription_name(sub_id)
+    sub_id, sub_name = utils.resolve_target_subscription()
     if not sub_id:
         print("ERROR: No subscription configured. Run configure.py first.")
         sys.exit(1)

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -147,6 +147,28 @@ def _resolve_subscription() -> tuple[str, str]:
     return sub_id, utils.get_subscription_name(sub_id)
 
 
+def _active_subscriptions() -> list:
+    """
+    Return the list of (id, name) subscriptions to scan in interactive mode.
+
+    Every subscription saved by configure.py is scanned ("Use all subscriptions"
+    works as expected); falls back to the default, then to an empty list when
+    nothing is configured.
+    """
+    cfg = utils.get_config()
+    pairs = [
+        (s["id"], s.get("name", s["id"]))
+        for s in cfg.get("subscriptions", [])
+        if s.get("id")
+    ]
+    if pairs:
+        return pairs
+    sub_id = cfg.get("default_subscription_id", "")
+    if sub_id:
+        return [(sub_id, utils.get_subscription_name(sub_id))]
+    return []
+
+
 # ---------------------------------------------------------------------------
 # Subprocess launcher
 # ---------------------------------------------------------------------------
@@ -183,22 +205,41 @@ def _print_banner() -> None:
     print("=" * 64)
 
 
-def _run_all_exporters(exporters: list, sub_id: str, sub_name: str) -> None:
-    print(f"\nRunning {len(exporters)} exporter(s)...\n")
+def _subs_label(subs: list) -> str:
+    if len(subs) == 1:
+        return subs[0][1]
+    return f"{len(subs)} subscriptions"
+
+
+def _run_exporter_across(path: str, label: str, subs: list) -> None:
+    for sub_id, sub_name in subs:
+        if len(subs) > 1:
+            print(f"  [{sub_name}]", end=" ", flush=True)
+        _run_exporter(path, sub_id, sub_name)
+
+
+def _run_all_exporters(exporters: list, subs: list) -> None:
+    print(f"\nRunning {len(exporters)} exporter(s) across {_subs_label(subs)}...\n")
     failed = []
-    for label, path in exporters:
-        print(f"  → {label}...", end=" ", flush=True)
-        rc = _run_exporter(path, sub_id, sub_name)
-        if rc == 0:
-            print("done")
-        else:
-            print(f"FAILED (exit {rc})")
-            failed.append(label)
+    for sub_id, sub_name in subs:
+        if len(subs) > 1:
+            print(f"=== Subscription: {sub_name} ({sub_id}) ===")
+        for label, path in exporters:
+            print(f"  → {label}...", end=" ", flush=True)
+            rc = _run_exporter(path, sub_id, sub_name)
+            if rc == 0:
+                print("done")
+            else:
+                print(f"FAILED (exit {rc})")
+                failed.append(f"{label} [{sub_name}]" if len(subs) > 1 else label)
+        if len(subs) > 1:
+            print()
     print()
+    total = len(exporters) * len(subs)
     if failed:
-        print(f"Completed with {len(failed)} failure(s): {', '.join(failed)}")
+        print(f"Completed with {len(failed)}/{total} failure(s): {', '.join(failed)}")
     else:
-        print(f"All {len(exporters)} exporter(s) completed successfully.")
+        print(f"All {total} exporter run(s) completed successfully.")
 
 
 def _package_outputs() -> None:
@@ -214,11 +255,11 @@ def _package_outputs() -> None:
 # Menus
 # ---------------------------------------------------------------------------
 
-def menu_tier1(sub_id: str, sub_name: str) -> None:
+def _run_tier_menu(title: str, exporters: list, subs: list) -> None:
     while True:
-        options = [label for label, _ in TIER1_EXPORTERS] + ["Run All Tier 1 Exporters"]
+        options = [label for label, _ in exporters] + [f"Run All {title} Exporters"]
         choice = utils.prompt_menu(
-            f"TIER 1 EXPORTERS  ({sub_name})",
+            f"{title.upper()} EXPORTERS  ({_subs_label(subs)})",
             options,
             allow_back=True,
             allow_exit=True,
@@ -228,78 +269,36 @@ def menu_tier1(sub_id: str, sub_name: str) -> None:
         if choice == "exit":
             sys.exit(0)
         if choice == len(options):
-            _run_all_exporters(TIER1_EXPORTERS, sub_id, sub_name)
+            _run_all_exporters(exporters, subs)
         else:
-            label, path = TIER1_EXPORTERS[choice - 1]
+            label, path = exporters[choice - 1]
             print(f"\nRunning: {label}")
-            _run_exporter(path, sub_id, sub_name)
+            _run_exporter_across(path, label, subs)
 
 
-def menu_tier2(sub_id: str, sub_name: str) -> None:
-    while True:
-        options = [label for label, _ in TIER2_EXPORTERS] + ["Run All Tier 2 Exporters"]
-        choice = utils.prompt_menu(
-            f"TIER 2 EXPORTERS  ({sub_name})",
-            options,
-            allow_back=True,
-            allow_exit=True,
-        )
-        if choice == "back":
-            return
-        if choice == "exit":
-            sys.exit(0)
-        if choice == len(options):
-            _run_all_exporters(TIER2_EXPORTERS, sub_id, sub_name)
-        else:
-            label, path = TIER2_EXPORTERS[choice - 1]
-            print(f"\nRunning: {label}")
-            _run_exporter(path, sub_id, sub_name)
+def menu_tier1(subs: list) -> None:
+    _run_tier_menu("Tier 1", TIER1_EXPORTERS, subs)
 
 
-def menu_governance(sub_id: str, sub_name: str) -> None:
-    while True:
-        options = [label for label, _ in GOVERNANCE_EXPORTERS] + ["Run All Governance Exporters"]
-        choice = utils.prompt_menu(
-            f"GOVERNANCE EXPORTERS  ({sub_name})",
-            options,
-            allow_back=True,
-            allow_exit=True,
-        )
-        if choice == "back":
-            return
-        if choice == "exit":
-            sys.exit(0)
-        if choice == len(options):
-            _run_all_exporters(GOVERNANCE_EXPORTERS, sub_id, sub_name)
-        else:
-            label, path = GOVERNANCE_EXPORTERS[choice - 1]
-            print(f"\nRunning: {label}")
-            _run_exporter(path, sub_id, sub_name)
+def menu_tier2(subs: list) -> None:
+    _run_tier_menu("Tier 2", TIER2_EXPORTERS, subs)
 
 
-def menu_monitoring(sub_id: str, sub_name: str) -> None:
-    while True:
-        options = [label for label, _ in MONITORING_EXPORTERS] + ["Run All Monitoring Exporters"]
-        choice = utils.prompt_menu(
-            f"MONITORING EXPORTERS  ({sub_name})",
-            options,
-            allow_back=True,
-            allow_exit=True,
-        )
-        if choice == "back":
-            return
-        if choice == "exit":
-            sys.exit(0)
-        if choice == len(options):
-            _run_all_exporters(MONITORING_EXPORTERS, sub_id, sub_name)
-        else:
-            label, path = MONITORING_EXPORTERS[choice - 1]
-            print(f"\nRunning: {label}")
-            _run_exporter(path, sub_id, sub_name)
+def menu_governance(subs: list) -> None:
+    _run_tier_menu("Governance", GOVERNANCE_EXPORTERS, subs)
 
 
-def menu_main(sub_id: str, sub_name: str) -> None:
+def menu_monitoring(subs: list) -> None:
+    _run_tier_menu("Monitoring", MONITORING_EXPORTERS, subs)
+
+
+def menu_main(subs: list) -> None:
     _print_banner()
+    if len(subs) > 1:
+        print(f"  Scanning {len(subs)} subscriptions:")
+        for _, sname in subs:
+            print(f"    • {sname}")
+        print()
     while True:
         options = [
             "Tier 1 Exporters   (Core infrastructure: VMs, VNets, Storage, Key Vault, RBAC…)",
@@ -311,7 +310,7 @@ def menu_main(sub_id: str, sub_name: str) -> None:
             "Configure           (subscription selection, environment settings)",
         ]
         choice = utils.prompt_menu(
-            "AZURESCAN MAIN MENU",
+            f"STRATUSSCAN MAIN MENU  ({_subs_label(subs)})",
             options,
             allow_back=False,
             allow_exit=True,
@@ -320,22 +319,26 @@ def menu_main(sub_id: str, sub_name: str) -> None:
             print("Goodbye.")
             sys.exit(0)
         if choice == 1:
-            menu_tier1(sub_id, sub_name)
+            menu_tier1(subs)
         elif choice == 2:
-            menu_tier2(sub_id, sub_name)
+            menu_tier2(subs)
         elif choice == 3:
-            menu_governance(sub_id, sub_name)
+            menu_governance(subs)
         elif choice == 4:
-            menu_monitoring(sub_id, sub_name)
+            menu_monitoring(subs)
         elif choice == 5:
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS + MONITORING_EXPORTERS, sub_id, sub_name)
+            _run_all_exporters(
+                TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS + MONITORING_EXPORTERS,
+                subs,
+            )
         elif choice == 6:
             _package_outputs()
         elif choice == 7:
             subprocess.run([sys.executable, str(Path(__file__).parent / "configure.py")])
-            # Reload config after configure
+            # Reload config after configure, then re-resolve active subscriptions
             import importlib
             importlib.reload(utils)
+            subs = _active_subscriptions() or subs
 
 
 # ---------------------------------------------------------------------------
@@ -343,18 +346,25 @@ def menu_main(sub_id: str, sub_name: str) -> None:
 # ---------------------------------------------------------------------------
 
 def main() -> None:
-    sub_id, sub_name = _resolve_subscription()
-
     if utils.is_auto_run():
         auto_subs = utils.get_auto_subscriptions()
-        all_subs = auto_subs if auto_subs else [sub_id]
-        for sid in all_subs:
-            sname = utils.get_subscription_name(sid)
-            print(f"\nAuto-run: scanning subscription {sname} ({sid})")
-            _run_all_exporters(TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS + MONITORING_EXPORTERS, sid, sname)
+        if not auto_subs:
+            sub_id, _ = _resolve_subscription()
+            auto_subs = [sub_id]
+        subs = [(sid, utils.get_subscription_name(sid)) for sid in auto_subs]
+        print(f"\nAuto-run: scanning {_subs_label(subs)}")
+        _run_all_exporters(
+            TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS + MONITORING_EXPORTERS,
+            subs,
+        )
         return
 
-    menu_main(sub_id, sub_name)
+    subs = _active_subscriptions()
+    if not subs:
+        print("\nNo subscription configured. Run configure.py first.")
+        print("  python configure.py")
+        sys.exit(1)
+    menu_main(subs)
 
 
 if __name__ == "__main__":

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -7,8 +7,8 @@ Launches Azure resource exporter scripts as subprocesses.
 This script never calls Azure APIs directly — all API work happens in the exporter scripts.
 
 Usage:
-    python azurescan.py
-    AZURESCAN_AUTO_RUN=1 AZURESCAN_SUBSCRIPTIONS=sub-id python azurescan.py
+    python stratusscan.py
+    STRATUSSCAN_AUTO_RUN=1 STRATUSSCAN_SUBSCRIPTIONS=sub-id python stratusscan.py
 """
 
 import os
@@ -30,7 +30,7 @@ except ImportError:
     sys.exit(1)
 
 utils.setup_logging("main-menu", log_to_file=True)
-utils.log_script_start("azurescan.py", "AzureScan Main Menu")
+utils.log_script_start("stratusscan.py", "StratusScan Main Menu")
 utils.log_system_info()
 
 SCRIPTS_DIR = Path(__file__).parent / "scripts"
@@ -130,7 +130,7 @@ MONITORING_EXPORTERS = [
 def _resolve_subscription() -> tuple[str, str]:
     """
     Return (subscription_id, subscription_name) from config or env var.
-    In auto-run mode, use the first subscription from AZURESCAN_SUBSCRIPTIONS.
+    In auto-run mode, use the first subscription from STRATUSSCAN_SUBSCRIPTIONS.
     """
     if utils.is_auto_run():
         auto_subs = utils.get_auto_subscriptions()
@@ -158,8 +158,8 @@ def _run_exporter(script_rel_path: str, sub_id: str, sub_name: str) -> int:
         return 1
 
     env = os.environ.copy()
-    env["AZURESCAN_SUBSCRIPTION_ID"] = sub_id
-    env["AZURESCAN_SUBSCRIPTION_NAME"] = sub_name
+    env["STRATUSSCAN_SUBSCRIPTION_ID"] = sub_id
+    env["STRATUSSCAN_SUBSCRIPTION_NAME"] = sub_name
 
     result = subprocess.run(
         [sys.executable, str(script_path)],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,6 +81,28 @@ def test_detect_environment_from_config_when_env_absent(monkeypatch):
     assert utils.detect_environment() == "government"
 
 
+def test_detect_azure_cloud_reads_az_config(monkeypatch, tmp_path):
+    (tmp_path / "config").write_text("[cloud]\nname = AzureUSGovernment\n")
+    monkeypatch.setenv("AZURE_CONFIG_DIR", str(tmp_path))
+    assert utils.detect_azure_cloud() == "government"
+
+    (tmp_path / "config").write_text("[cloud]\nname = AzureCloud\n")
+    assert utils.detect_azure_cloud() == "public"
+
+
+def test_detect_azure_cloud_returns_none_when_absent(monkeypatch, tmp_path):
+    monkeypatch.setenv("AZURE_CONFIG_DIR", str(tmp_path))  # empty dir, no config file
+    assert utils.detect_azure_cloud() is None
+
+
+def test_detect_environment_autodetects_when_unconfigured(monkeypatch, tmp_path):
+    monkeypatch.delenv("AZURE_ENVIRONMENT", raising=False)
+    # no config.json on disk → falls through to az auto-detect
+    monkeypatch.setattr(utils.Path, "exists", lambda self: False)
+    monkeypatch.setattr(utils, "detect_azure_cloud", lambda: "government")
+    assert utils.detect_environment() == "government"
+
+
 def test_is_service_available_in_environment_contract():
     assert utils.is_service_available_in_environment("compute", "public") is True
     assert utils.is_service_available_in_environment("network", "government") is True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,18 +16,18 @@ def test_get_current_timestamp_is_mm_dd_yyyy():
 
 
 def test_is_auto_run_reads_env(monkeypatch):
-    monkeypatch.delenv("AZURESCAN_AUTO_RUN", raising=False)
+    monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
     assert utils.is_auto_run() is False
-    monkeypatch.setenv("AZURESCAN_AUTO_RUN", "1")
+    monkeypatch.setenv("STRATUSSCAN_AUTO_RUN", "1")
     assert utils.is_auto_run() is True
-    monkeypatch.setenv("AZURESCAN_AUTO_RUN", "0")
+    monkeypatch.setenv("STRATUSSCAN_AUTO_RUN", "0")
     assert utils.is_auto_run() is False
 
 
 def test_get_auto_subscriptions_parses_csv(monkeypatch):
-    monkeypatch.delenv("AZURESCAN_SUBSCRIPTIONS", raising=False)
+    monkeypatch.delenv("STRATUSSCAN_SUBSCRIPTIONS", raising=False)
     assert utils.get_auto_subscriptions() == []
-    monkeypatch.setenv("AZURESCAN_SUBSCRIPTIONS", " sub-a , sub-b ,, sub-c ")
+    monkeypatch.setenv("STRATUSSCAN_SUBSCRIPTIONS", " sub-a , sub-b ,, sub-c ")
     assert utils.get_auto_subscriptions() == ["sub-a", "sub-b", "sub-c"]
 
 

--- a/utils.py
+++ b/utils.py
@@ -333,23 +333,56 @@ def save_config(data: Dict) -> None:
 _GOV_UNAVAILABLE: List[str] = []
 
 
+def detect_azure_cloud() -> Optional[str]:
+    """
+    Best-effort detection of the active Azure cloud from the Azure CLI context.
+
+    Reads the active cloud from the Azure CLI config ([cloud] name = ...), which
+    Cloud Shell and `az cloud set` populate. Honors AZURE_CONFIG_DIR. Returns
+    'government', 'public', or None if it cannot be determined.
+    """
+    import configparser
+
+    config_dir = os.environ.get("AZURE_CONFIG_DIR") or str(Path.home() / ".azure")
+    try:
+        parser = configparser.ConfigParser()
+        parser.read(Path(config_dir) / "config")
+        name = parser.get("cloud", "name", fallback="").strip().lower()
+    except Exception:
+        return None
+    if name == "azureusgovernment":
+        return "government"
+    if name == "azurecloud":
+        return "public"
+    return None
+
+
 def detect_environment() -> str:
     """
     Return 'government' if running in AzureUSGovernment, otherwise 'public'.
 
     Detection order:
     1. AZURE_ENVIRONMENT env var ('AzureUSGovernment' → 'government')
-    2. config.json 'environment' key
-    3. Default: 'public'
+    2. config.json 'environment' key (only if a config.json has been written)
+    3. Auto-detected active Azure CLI cloud (Cloud Shell / `az cloud set`)
+    4. Default: 'public'
     """
     env_var = os.environ.get("AZURE_ENVIRONMENT", "").strip().lower()
     if env_var in ("azureusgovernment", "government", "usgov"):
         return "government"
     if env_var in ("azurepubliccloud", "public", "azurecloud"):
         return "public"
-    cfg = get_config()
-    if cfg.get("environment", "public").lower() in ("government", "azureusgovernment"):
-        return "government"
+
+    config_path = Path(__file__).parent / "config.json"
+    if config_path.exists():
+        cfg = get_config()
+        if cfg.get("environment", "public").lower() in ("government", "azureusgovernment"):
+            return "government"
+        return "public"
+
+    detected = detect_azure_cloud()
+    if detected:
+        return detected
     return "public"
 
 

--- a/utils.py
+++ b/utils.py
@@ -592,6 +592,27 @@ def get_subscription_name(subscription_id: str) -> str:
     return subscription_id
 
 
+def resolve_target_subscription() -> tuple:
+    """
+    Return (subscription_id, subscription_name) for an exporter run.
+
+    Prefers the subscription injected by stratusscan.py via the
+    STRATUSSCAN_SUBSCRIPTION_ID / _NAME env vars — this is how multi-subscription
+    runs target each subscription in turn. Falls back to the configured default
+    when an exporter is run directly. Returns ("", "") when nothing is configured.
+    """
+    sub_id = os.environ.get("STRATUSSCAN_SUBSCRIPTION_ID", "").strip()
+    if sub_id:
+        sub_name = os.environ.get("STRATUSSCAN_SUBSCRIPTION_NAME", "").strip()
+        return sub_id, (sub_name or get_subscription_name(sub_id))
+
+    cfg = get_config()
+    sub_id = cfg.get("default_subscription_id", "")
+    if not sub_id:
+        return "", ""
+    return sub_id, get_subscription_name(sub_id)
+
+
 # ---------------------------------------------------------------------------
 # Interactive menu (shared by stratusscan.py and configure.py)
 # ---------------------------------------------------------------------------

--- a/utils.py
+++ b/utils.py
@@ -3,7 +3,7 @@
 StratusScanCLI-Azure — Shared Utilities Module
 Version: v0.1.0
 
-Shared utility functions for all AzureScan exporter scripts.
+Shared utility functions for all StratusScan exporter scripts.
 Handles credential management, client factory, environment detection,
 logging, Excel output, and config I/O.
 
@@ -57,10 +57,10 @@ def _cleanup_old_logs(logs_dir: Path, retention_days: int = 14) -> None:
         pass
 
 
-def setup_logging(script_name: str = "azurescan", log_to_file: bool = True) -> logging.Logger:
+def setup_logging(script_name: str = "stratusscan", log_to_file: bool = True) -> logging.Logger:
     global logger, _logging_configured
 
-    logger = logging.getLogger("azurescan")
+    logger = logging.getLogger("stratusscan")
     logger.setLevel(logging.DEBUG)
     logger.handlers = []
 
@@ -86,7 +86,7 @@ def setup_logging(script_name: str = "azurescan", log_to_file: bool = True) -> l
             fh.setLevel(logging.DEBUG)
             fh.setFormatter(file_fmt)
             logger.addHandler(fh)
-            logger.info("AzureScan logging initialized — %s", log_path)
+            logger.info("StratusScan logging initialized — %s", log_path)
         except Exception as exc:
             logger.warning("File logging unavailable: %s", exc)
 
@@ -100,7 +100,7 @@ def setup_logging(script_name: str = "azurescan", log_to_file: bool = True) -> l
 def get_logger() -> logging.Logger:
     global logger, _logging_configured
     if logger is None:
-        nl = logging.getLogger("azurescan")
+        nl = logging.getLogger("stratusscan")
         if not nl.handlers:
             nl.addHandler(logging.NullHandler())
         return nl
@@ -127,11 +127,11 @@ def log_system_info() -> None:
 # ---------------------------------------------------------------------------
 
 def is_auto_run() -> bool:
-    return os.environ.get("AZURESCAN_AUTO_RUN", "").strip() == "1"
+    return os.environ.get("STRATUSSCAN_AUTO_RUN", "").strip() == "1"
 
 
 def get_auto_subscriptions() -> List[str]:
-    raw = os.environ.get("AZURESCAN_SUBSCRIPTIONS", "").strip()
+    raw = os.environ.get("STRATUSSCAN_SUBSCRIPTIONS", "").strip()
     if not raw:
         return []
     return [s.strip() for s in raw.split(",") if s.strip()]
@@ -560,7 +560,7 @@ def get_subscription_name(subscription_id: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Interactive menu (shared by azurescan.py and configure.py)
+# Interactive menu (shared by stratusscan.py and configure.py)
 # ---------------------------------------------------------------------------
 
 def prompt_menu(


### PR DESCRIPTION
Three related improvements from Nick's review, in three commits.

## 1. Rename `azurescan` → `stratusscan` (full)
The main entrypoint and everything that referenced it:
- `azurescan.py` → **`stratusscan.py`**
- console scripts: `azurescan` / `azurescan-configure` → **`stratusscan`** / **`stratusscan-configure`**
- env vars: `AZURESCAN_*` → **`STRATUSSCAN_*`** (`AUTO_RUN`, `SUBSCRIPTIONS`, `SUBSCRIPTION_ID/_NAME`, `BOOTSTRAP_ATTEMPTED`)
- logger name, py-modules, display strings, README/CLAUDE.md/CONTRIBUTING.md/docs/tests

⚠️ **Breaking for CI:** the env vars changed. The old `AZURESCAN_*` names no longer work — update any automation to `STRATUSSCAN_*`.

## 2. Auto-detect the Azure cloud (AWS-partition-style)
`utils.detect_azure_cloud()` reads the active cloud from the Azure CLI config (`[cloud] name`, honoring `AZURE_CONFIG_DIR`) — populated by Cloud Shell and `az cloud set`. `detect_environment()` now falls back to it when **no `config.json` exists yet**, so a fresh run knows public vs government without a manual pick.

Precedence: `AZURE_ENVIRONMENT` env > `config.json` (if written) > **az auto-detect** > public. An explicit `configure` choice still wins; the env var still overrides everything. The wizard shows the detected cloud and tags the matching option `[detected]`.

## 3. Fix multi-subscription scanning (real bug)
stratusscan injected `STRATUSSCAN_SUBSCRIPTION_ID` into each exporter subprocess, **but no exporter read it** — all 69 read `config.default_subscription_id`. So **"Use all subscriptions" (and CI `*_SUBSCRIPTIONS=a,b,c`) silently scanned only the default sub.**

Fixed end-to-end:
- `utils.resolve_target_subscription()` — prefers the injected `STRATUSSCAN_SUBSCRIPTION_ID/_NAME`, falls back to config default. All 69 exporter `__main__` blocks now call it (`subscriptions_export` is tenant-level, untouched).
- stratusscan menus operate on a **list** of active subscriptions (`_active_subscriptions()` = every sub saved by configure); run-all, tier menus, and single-exporter runs loop over them with per-subscription output labels. Auto-run uses the same path.

## Verification
- Full tree compiles (bootstrap/utils/stratusscan/configure + 70 scripts).
- `tests/test_utils.py` **16/16** (added auto-detect + precedence tests).
- Registry invariant intact: **70 entries == 70 scripts**; old `azurescan.py` removed; no `azurescan`/`AZURESCAN` references remain.
- Multi-sub logic exercised with a fake 3-sub config: `_active_subscriptions`, `_subs_label`, and `resolve_target_subscription` (env-override / config-default / unconfigured) all correct.
- Not run against live Azure — monkizzle's validation gate (now multi-sub-capable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)