### PR TITLE
feat(ux): zero-config first run — auto-discover subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,13 @@ The tool is designed to work in a fresh [Azure Cloud Shell](https://shell.azure.
 ```bash
 git clone https://github.com/ColonelPanicX/stratusscan-cli-azure.git
 cd stratusscan-cli-azure
-python configure.py
 python stratusscan.py
 ```
+
+On first run with no config, StratusScan auto-detects the Azure cloud (public vs
+government) and discovers every accessible subscription — no setup step required.
+Run `python configure.py` only if you want to **narrow** to specific subscriptions
+or persist a choice.
 
 ### Local Machine
 
@@ -48,14 +52,14 @@ Requires [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) in
 git clone https://github.com/ColonelPanicX/stratusscan-cli-azure.git
 cd stratusscan-cli-azure
 
-# Authenticate
+# Authenticate (StratusScan auto-detects the cloud and subscriptions from this)
 az login
 
-# Configure subscription and environment
-python configure.py
-
-# Launch StratusScan
+# Launch StratusScan — discovers everything on first run
 python stratusscan.py
+
+# Optional: narrow to specific subscriptions / persist a choice
+python configure.py
 ```
 
 ### pip install (once published)

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -127,26 +127,6 @@ MONITORING_EXPORTERS = [
 # Subscription resolution
 # ---------------------------------------------------------------------------
 
-def _resolve_subscription() -> tuple[str, str]:
-    """
-    Return (subscription_id, subscription_name) from config or env var.
-    In auto-run mode, use the first subscription from STRATUSSCAN_SUBSCRIPTIONS.
-    """
-    if utils.is_auto_run():
-        auto_subs = utils.get_auto_subscriptions()
-        if auto_subs:
-            sub_id = auto_subs[0]
-            return sub_id, utils.get_subscription_name(sub_id)
-
-    cfg = utils.get_config()
-    sub_id = cfg.get("default_subscription_id", "")
-    if not sub_id:
-        print("\nNo subscription configured. Run configure.py first.")
-        print("  python configure.py")
-        sys.exit(1)
-    return sub_id, utils.get_subscription_name(sub_id)
-
-
 def _active_subscriptions() -> list:
     """
     Return the list of (id, name) subscriptions to scan in interactive mode.
@@ -167,6 +147,32 @@ def _active_subscriptions() -> list:
     if sub_id:
         return [(sub_id, utils.get_subscription_name(sub_id))]
     return []
+
+
+def _autodiscover_subscriptions() -> list:
+    """
+    Discover all accessible (enabled) subscriptions when nothing is configured,
+    so stratusscan.py runs with zero setup. configure.py is then only needed to
+    persist a choice or narrow to specific subscriptions.
+    """
+    print("\nNo configuration found — auto-detecting environment and discovering subscriptions...")
+    try:
+        discovered = utils.list_subscriptions()
+    except Exception as exc:
+        print(f"  Subscription discovery failed: {exc}")
+        return []
+    pairs = [
+        (s["id"], s.get("name", s["id"]))
+        for s in discovered
+        if s.get("id") and (not s.get("state") or "enabled" in str(s["state"]).lower())
+    ]
+    if pairs:
+        env_label = (
+            "AzureUSGovernment" if utils.detect_environment() == "government" else "AzurePublicCloud"
+        )
+        print(f"  Environment: {env_label}")
+        print(f"  Found {len(pairs)} accessible subscription(s). Scanning all — run Configure to narrow.")
+    return pairs
 
 
 # ---------------------------------------------------------------------------
@@ -348,10 +354,13 @@ def menu_main(subs: list) -> None:
 def main() -> None:
     if utils.is_auto_run():
         auto_subs = utils.get_auto_subscriptions()
-        if not auto_subs:
-            sub_id, _ = _resolve_subscription()
-            auto_subs = [sub_id]
-        subs = [(sid, utils.get_subscription_name(sid)) for sid in auto_subs]
+        if auto_subs:
+            subs = [(sid, utils.get_subscription_name(sid)) for sid in auto_subs]
+        else:
+            subs = _active_subscriptions() or _autodiscover_subscriptions()
+        if not subs:
+            print("\nNo subscriptions to scan (none set, configured, or discoverable).")
+            sys.exit(1)
         print(f"\nAuto-run: scanning {_subs_label(subs)}")
         _run_all_exporters(
             TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS + MONITORING_EXPORTERS,
@@ -359,10 +368,10 @@ def main() -> None:
         )
         return
 
-    subs = _active_subscriptions()
+    subs = _active_subscriptions() or _autodiscover_subscriptions()
     if not subs:
-        print("\nNo subscription configured. Run configure.py first.")
-        print("  python configure.py")
+        print("\nNo accessible subscriptions found.")
+        print("  Check your Azure sign-in (e.g. `az login`), then try again.")
         sys.exit(1)
     menu_main(subs)
 


### PR DESCRIPTION
Follow-up to #99: remove the mandatory `configure.py` step.

## Before
A fresh `python stratusscan.py` with no `config.json` printed *"No subscription configured. Run configure.py first."* and exited. You had to run the wizard before you could do anything.

## After
First run with no config now **auto-detects the cloud** (from #99) **and auto-discovers every accessible (enabled) subscription**, then drops straight into the menu scanning all of them. `configure.py` is now **optional** — only for narrowing to specific subscriptions or persisting a choice.

- `_autodiscover_subscriptions()` — discovers via `utils.list_subscriptions()`, filters to enabled subs, prints the detected environment + count, returns `[]` gracefully on failure.
- Both **interactive** and **auto-run** paths fall back to discovery when nothing is set/configured. So `STRATUSSCAN_AUTO_RUN=1 python stratusscan.py` also works zero-config.
- Removed the now-dead `_resolve_subscription()`; the no-subscriptions message now points at `az login` instead of `configure.py`.
- README quickstart updated — `configure.py` shown as optional.

## Verification
- Compiles; `tests/test_utils.py` 16/16.
- Mock run: empty config → discovery returns enabled subs only (3 of 4, drops Disabled), prints env + count; failure → `[]`.
- No stale `configure.py first` / dead refs remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)