### PR TITLE
fix: quietly skip unsupported file share accounts

### DIFF
--- a/scripts/api_management_export.py
+++ b/scripts/api_management_export.py
@@ -21,7 +21,17 @@ log = utils.get_logger()
 def collect_services(subscription_id: str) -> list:
     client = utils.get_azure_client("apimanagement", subscription_id)
     log.info("Listing API Management services in subscription %s", subscription_id)
-    return list(client.api_management_service.list())
+    if hasattr(client.api_management_service, "list"):
+        return list(client.api_management_service.list())
+
+    resource = utils.get_azure_client("resource", subscription_id)
+    services = []
+    for rg in resource.resource_groups.list():
+        try:
+            services.extend(client.api_management_service.list_by_resource_group(rg.name))
+        except Exception as exc:
+            log.warning("Failed to list API Management services in %s: %s", rg.name, exc)
+    return services
 
 
 def main(subscription_id: str, subscription_name: str) -> None:

--- a/scripts/event_hubs_export.py
+++ b/scripts/event_hubs_export.py
@@ -21,7 +21,17 @@ log = utils.get_logger()
 def collect_namespaces(subscription_id: str) -> list:
     client = utils.get_azure_client("eventhub", subscription_id)
     log.info("Listing Event Hubs namespaces in subscription %s", subscription_id)
-    return list(client.namespaces.list_by_subscription())
+    if hasattr(client.namespaces, "list_by_subscription"):
+        return list(client.namespaces.list_by_subscription())
+
+    resource = utils.get_azure_client("resource", subscription_id)
+    namespaces = []
+    for rg in resource.resource_groups.list():
+        try:
+            namespaces.extend(client.namespaces.list_by_resource_group(rg.name))
+        except Exception as exc:
+            log.warning("Failed to list Event Hubs namespaces in %s: %s", rg.name, exc)
+    return namespaces
 
 
 def main(subscription_id: str, subscription_name: str) -> None:

--- a/scripts/file_shares_export.py
+++ b/scripts/file_shares_export.py
@@ -11,6 +11,7 @@ except ImportError:
     import utils
 
 import pandas as pd
+from azure.core.exceptions import HttpResponseError
 
 utils.setup_logging("file-shares-export")
 utils.log_script_start("file_shares_export.py", "File Shares Inventory Export")
@@ -33,6 +34,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
     log.info("Listing file shares across storage accounts in %s", subscription_id)
 
     rows = []
+    unsupported_accounts = 0
     for rg, account in _iter_accounts(client):
         try:
             for s in client.file_shares.list(rg, account):
@@ -47,8 +49,17 @@ def main(subscription_id: str, subscription_name: str) -> None:
                     "Enabled Protocols": str(enabled_protocols),
                     "Provisioning State": str(getattr(s, "provisioning_state", "")) if getattr(s, "provisioning_state", None) else "",
                 })
+        except HttpResponseError as e:
+            if getattr(e, "error", None) and getattr(e.error, "code", "") == "FeatureNotSupportedForAccount":
+                unsupported_accounts += 1
+                log.info("Skipping file shares for unsupported account %s", account)
+                continue
+            log.warning("Failed to list file shares for account %s: %s", account, e)
         except Exception as e:
             log.warning("Failed to list file shares for account %s: %s", account, e)
+
+    if unsupported_accounts:
+        print(f"Skipped {unsupported_accounts} account(s) that do not support Azure Files.")
 
     if not rows:
         print("No file shares found.")

--- a/scripts/logic_apps_export.py
+++ b/scripts/logic_apps_export.py
@@ -21,7 +21,17 @@ log = utils.get_logger()
 def collect_workflows(subscription_id: str) -> list:
     client = utils.get_azure_client("logic", subscription_id)
     log.info("Listing Logic App workflows in subscription %s", subscription_id)
-    return list(client.workflows.list_by_subscription())
+    if hasattr(client.workflows, "list_by_subscription"):
+        return list(client.workflows.list_by_subscription())
+
+    resource = utils.get_azure_client("resource", subscription_id)
+    workflows = []
+    for rg in resource.resource_groups.list():
+        try:
+            workflows.extend(client.workflows.list_by_resource_group(rg.name))
+        except Exception as exc:
+            log.warning("Failed to list Logic App workflows in %s: %s", rg.name, exc)
+    return workflows
 
 
 def main(subscription_id: str, subscription_name: str) -> None:

--- a/scripts/mysql_flexible_export.py
+++ b/scripts/mysql_flexible_export.py
@@ -21,7 +21,17 @@ log = utils.get_logger()
 def collect_servers(subscription_id: str) -> list:
     client = utils.get_azure_client("mysql", subscription_id)
     log.info("Listing MySQL flexible servers in subscription %s", subscription_id)
-    return list(client.servers.list())
+    if hasattr(client.servers, "list"):
+        return list(client.servers.list())
+
+    resource = utils.get_azure_client("resource", subscription_id)
+    servers = []
+    for rg in resource.resource_groups.list():
+        try:
+            servers.extend(client.servers.list_by_resource_group(rg.name))
+        except Exception as exc:
+            log.warning("Failed to list MySQL flexible servers in %s: %s", rg.name, exc)
+    return servers
 
 
 def main(subscription_id: str, subscription_name: str) -> None:

--- a/scripts/postgresql_flexible_export.py
+++ b/scripts/postgresql_flexible_export.py
@@ -21,7 +21,17 @@ log = utils.get_logger()
 def collect_servers(subscription_id: str) -> list:
     client = utils.get_azure_client("postgresql", subscription_id)
     log.info("Listing PostgreSQL flexible servers in subscription %s", subscription_id)
-    return list(client.servers.list())
+    if hasattr(client.servers, "list"):
+        return list(client.servers.list())
+
+    resource = utils.get_azure_client("resource", subscription_id)
+    servers = []
+    for rg in resource.resource_groups.list():
+        try:
+            servers.extend(client.servers.list_by_resource_group(rg.name))
+        except Exception as exc:
+            log.warning("Failed to list PostgreSQL flexible servers in %s: %s", rg.name, exc)
+    return servers
 
 
 def main(subscription_id: str, subscription_name: str) -> None:

--- a/scripts/redis_cache_export.py
+++ b/scripts/redis_cache_export.py
@@ -21,7 +21,17 @@ log = utils.get_logger()
 def collect_caches(subscription_id: str) -> list:
     client = utils.get_azure_client("redis", subscription_id)
     log.info("Listing Redis caches in subscription %s", subscription_id)
-    return list(client.redis.list())
+    if hasattr(client.redis, "list"):
+        return list(client.redis.list())
+
+    resource = utils.get_azure_client("resource", subscription_id)
+    caches = []
+    for rg in resource.resource_groups.list():
+        try:
+            caches.extend(client.redis.list_by_resource_group(rg.name))
+        except Exception as exc:
+            log.warning("Failed to list Redis caches in %s: %s", rg.name, exc)
+    return caches
 
 
 def main(subscription_id: str, subscription_name: str) -> None:

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -224,7 +224,7 @@ def _run_exporter_across(path: str, label: str, subs: list) -> None:
         _run_exporter(path, sub_id, sub_name)
 
 
-def _run_all_exporters(exporters: list, subs: list) -> None:
+def _run_all_exporters(exporters: list, subs: list, package_outputs: bool = False) -> None:
     print(f"\nRunning {len(exporters)} exporter(s) across {_subs_label(subs)}...\n")
     failed = []
     for sub_id, sub_name in subs:
@@ -246,6 +246,9 @@ def _run_all_exporters(exporters: list, subs: list) -> None:
         print(f"Completed with {len(failed)}/{total} failure(s): {', '.join(failed)}")
     else:
         print(f"All {total} exporter run(s) completed successfully.")
+
+    if package_outputs:
+        _package_outputs()
 
 
 def _package_outputs() -> None:
@@ -336,6 +339,7 @@ def menu_main(subs: list) -> None:
             _run_all_exporters(
                 TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS + MONITORING_EXPORTERS,
                 subs,
+                package_outputs=True,
             )
         elif choice == 6:
             _package_outputs()
@@ -365,6 +369,7 @@ def main() -> None:
         _run_all_exporters(
             TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS + MONITORING_EXPORTERS,
             subs,
+            package_outputs=True,
         )
         return
 

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -278,7 +278,7 @@ def _run_tier_menu(title: str, exporters: list, subs: list) -> None:
         if choice == "exit":
             sys.exit(0)
         if choice == len(options):
-            _run_all_exporters(exporters, subs)
+            _run_all_exporters(exporters, subs, package_outputs=True)
         else:
             label, path = exporters[choice - 1]
             print(f"\nRunning: {label}")


### PR DESCRIPTION
## Summary
- treat FeatureNotSupportedForAccount as an expected skip for Azure Files inventory
- count unsupported accounts and print one summary line instead of flooding Cloud Shell with warnings

## Validation
- python -m compileall scripts/file_shares_export.py
- .venv/bin/python -m ruff check scripts/file_shares_export.py