### PR TITLE
Label output archive ZIPs by run scope

### DIFF
--- a/stratusscan.py
+++ b/stratusscan.py
@@ -267,7 +267,12 @@ def _run_exporter_across(path: str, label: str, subs: list) -> None:
         _run_exporter(path, sub_id, sub_name)
 
 
-def _run_all_exporters(exporters: list, subs: list, package_outputs: bool = False) -> None:
+def _run_all_exporters(
+    exporters: list,
+    subs: list,
+    package_outputs: bool = False,
+    package_label: str | None = None,
+) -> None:
     print(f"\nRunning {len(exporters)} exporter(s) across {_subs_label(subs)}...\n")
     failed = []
     for sub_id, sub_name in subs:
@@ -291,11 +296,11 @@ def _run_all_exporters(exporters: list, subs: list, package_outputs: bool = Fals
         print(f"All {total} exporter run(s) completed successfully.")
 
     if package_outputs:
-        _package_outputs()
+        _package_outputs(package_label)
 
 
-def _package_outputs() -> None:
-    zip_path = utils.archive_outputs()
+def _package_outputs(label: str | None = None) -> None:
+    zip_path = utils.archive_outputs(label)
     if not zip_path:
         print("\nNo exports found in output/ to package.")
         return
@@ -323,7 +328,12 @@ def _run_tier_menu(title: str, exporters: list, subs: list) -> None:
         if choice == len(options):
             target = _select_run_all_subs(subs)
             if target:
-                _run_all_exporters(exporters, target, package_outputs=True)
+                _run_all_exporters(
+                    exporters,
+                    target,
+                    package_outputs=True,
+                    package_label=title.replace(" ", "").lower(),
+                )
         else:
             label, path = exporters[choice - 1]
             print(f"\nRunning: {label}")
@@ -388,6 +398,7 @@ def menu_main(subs: list) -> None:
                     TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS + MONITORING_EXPORTERS,
                     target,
                     package_outputs=True,
+                    package_label="all",
                 )
         elif choice == 6:
             _package_outputs()
@@ -418,6 +429,7 @@ def main() -> None:
             TIER1_EXPORTERS + TIER2_EXPORTERS + GOVERNANCE_EXPORTERS + MONITORING_EXPORTERS,
             subs,
             package_outputs=True,
+            package_label="all",
         )
         return
 

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -15,6 +15,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Optional
 
 # Ensure local modules are importable from the project root.
 sys.path.insert(0, str(Path(__file__).parent))
@@ -271,7 +272,7 @@ def _run_all_exporters(
     exporters: list,
     subs: list,
     package_outputs: bool = False,
-    package_label: str | None = None,
+    package_label: Optional[str] = None,
 ) -> None:
     print(f"\nRunning {len(exporters)} exporter(s) across {_subs_label(subs)}...\n")
     failed = []
@@ -299,7 +300,7 @@ def _run_all_exporters(
         _package_outputs(package_label)
 
 
-def _package_outputs(label: str | None = None) -> None:
+def _package_outputs(label: Optional[str] = None) -> None:
     zip_path = utils.archive_outputs(label)
     if not zip_path:
         print("\nNo exports found in output/ to package.")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,6 +46,19 @@ def test_create_export_filename_uppercases_and_sanitizes():
     assert name.startswith("A-B-C-D-")
 
 
+def test_archive_outputs_includes_optional_label(monkeypatch, tmp_path):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    (output_dir / "sample.xlsx").write_text("xlsx")
+    monkeypatch.setattr(utils, "__file__", str(tmp_path / "utils.py"))
+    monkeypatch.setattr(utils, "get_current_timestamp", lambda: "06.15.2026")
+
+    zip_path = utils.archive_outputs("tier1")
+
+    assert zip_path is not None
+    assert zip_path.replace("\\", "/").endswith("/output/exports-tier1-06.15.2026.zip")
+
+
 def test_extract_resource_group_handles_casing_and_missing():
     assert (
         utils.extract_resource_group(

--- a/utils.py
+++ b/utils.py
@@ -182,7 +182,7 @@ def extract_resource_group(resource_id: Optional[str]) -> str:
     return ""
 
 
-def archive_outputs() -> Optional[str]:
+def archive_outputs(label: Optional[str] = None) -> Optional[str]:
     """
     Bundle every .xlsx in output/ into a single dated zip.
 
@@ -195,7 +195,8 @@ def archive_outputs() -> Optional[str]:
     if not exports:
         return None
 
-    zip_path = out_dir / f"exports-{get_current_timestamp()}.zip"
+    label_part = f"-{_sanitize_name(label).lower()}" if label else ""
+    zip_path = out_dir / f"exports{label_part}-{get_current_timestamp()}.zip"
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
         for export in exports:
             zf.write(export, arcname=export.name)


### PR DESCRIPTION
## Summary
- add an optional archive label to output ZIP creation
- name section Run All archives by scope: exports-tier1-<date>.zip, exports-tier2-<date>.zip, exports-governance-<date>.zip, exports-monitoring-<date>.zip
- name full Run All / auto-run archives exports-all-<date>.zip while leaving manual Package Outputs as exports-<date>.zip

## Validation
- python -m compileall utils.py stratusscan.py
- .venv/bin/python -m pytest tests/test_utils.py -q
- .venv/bin/python -m ruff check stratusscan.py tests/test_utils.py