### PR TITLE
fix(cost): resolve VM power state and split Advisor savings by period

### DIFF
--- a/scripts/advisor_export.py
+++ b/scripts/advisor_export.py
@@ -31,15 +31,64 @@ def _parse_resource_id(resource_id: str) -> tuple:
     return rname, rtype
 
 
-def _extract_savings(extended_properties: dict) -> str:
-    if not extended_properties:
+_MONTHLY_SAVINGS_KEYS = ("savingsAmount", "monthlySavingsAmount")
+_ANNUAL_SAVINGS_KEYS = ("annualSavingsAmount", "estimatedAnnualSavings")
+
+
+def _to_number(value):
+    """Coerce an extendedProperties value to a number. ARM returns these as strings."""
+    if value is None or value == "":
         return ""
-    for key in ("savingsAmount", "annualSavingsAmount", "estimatedAnnualSavings", "savings"):
-        val = extended_properties.get(key)
-        if val is not None:
-            currency = extended_properties.get("savingsCurrency", "USD")
-            return f"{val} {currency}"
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return ""
+
+
+def _first_number(extended_properties: dict, keys):
+    for key in keys:
+        number = _to_number(extended_properties.get(key))
+        if number != "":
+            return number
     return ""
+
+
+def _extract_savings(extended_properties: dict) -> dict:
+    """Split Advisor savings into explicit monthly and annual fields.
+
+    Advisor cost recommendations expose both periods in extendedProperties. Emitting
+    one collapsed figure loses which period it came from — a 12x ambiguity. Keys that
+    are absent stay blank rather than being derived from the other period.
+    """
+    blank = {
+        "Potential Savings (Monthly)": "",
+        "Potential Savings (Annual)": "",
+        "Savings Currency": "",
+        "Reservation Term": "",
+        "Lookback (days)": "",
+        "Region": "",
+    }
+    if not extended_properties:
+        return blank
+
+    monthly = _first_number(extended_properties, _MONTHLY_SAVINGS_KEYS)
+    annual = _first_number(extended_properties, _ANNUAL_SAVINGS_KEYS)
+
+    currency = ""
+    if monthly != "" or annual != "":
+        currency = extended_properties.get("savingsCurrency") or "USD"
+
+    lookback = extended_properties.get("lookbackPeriod") or ""
+    lookback_number = _to_number(lookback)
+
+    return {
+        "Potential Savings (Monthly)": monthly,
+        "Potential Savings (Annual)": annual,
+        "Savings Currency": currency,
+        "Reservation Term": extended_properties.get("term") or "",
+        "Lookback (days)": lookback_number if lookback_number != "" else lookback,
+        "Region": extended_properties.get("region") or "",
+    }
 
 
 def collect_recommendations(subscription_id: str) -> list:
@@ -64,7 +113,7 @@ def collect_recommendations(subscription_id: str) -> list:
             if hasattr(last_updated, "isoformat"):
                 last_updated = last_updated.isoformat()
 
-            rows.append({
+            row = {
                 "Category": getattr(rec, "category", "") or "",
                 "Impact": getattr(rec, "impact", "") or "",
                 "Resource ID": resource_id,
@@ -72,9 +121,10 @@ def collect_recommendations(subscription_id: str) -> list:
                 "Resource Type": rtype or getattr(rec, "impacted_field", "") or "",
                 "Recommendation": problem,
                 "Solution": solution,
-                "Potential Savings": _extract_savings(extended),
-                "Last Updated": last_updated,
-            })
+            }
+            row.update(_extract_savings(extended))
+            row["Last Updated"] = last_updated
+            rows.append(row)
     except Exception as e:
         log.warning("Failed to list Advisor recommendations: %s", e)
 

--- a/scripts/virtual_machines_export.py
+++ b/scripts/virtual_machines_export.py
@@ -18,10 +18,48 @@ utils.log_script_start("virtual_machines_export.py", "Azure Virtual Machines Exp
 log = utils.get_logger()
 
 
-def collect_vms(subscription_id: str) -> list:
-    client = utils.get_azure_client("compute", subscription_id)
-    log.info("Listing all VMs in subscription %s", subscription_id)
+def collect_vms(client) -> list:
     return list(client.virtual_machines.list_all())
+
+
+def collect_power_states(client) -> dict:
+    """Map lowercased VM resource id to power state via one status-scoped list call.
+
+    `list_all()` alone never populates `instance_view`, so power state has to come
+    from a second, status-only pass. The two calls are kept separate because the
+    statusOnly payload is not guaranteed to carry the inventory properties
+    (size, image, zones, tags) the export also needs.
+    """
+    states = {}
+    try:
+        for vm in client.virtual_machines.list_all(status_only="true"):
+            state = _power_state_from_statuses(getattr(vm.instance_view, "statuses", None))
+            if vm.id and state:
+                states[vm.id.lower()] = state
+    except Exception as e:
+        log.warning("statusOnly VM listing failed (%s) — falling back to per-VM instance view", e)
+    return states
+
+
+def _power_state_from_statuses(statuses) -> str:
+    if not statuses:
+        return ""
+    for s in statuses:
+        code = getattr(s, "code", None)
+        if code and code.startswith("PowerState/"):
+            return code.replace("PowerState/", "")
+    return ""
+
+
+def _instance_view_power_state(client, resource_group: str, name: str) -> str:
+    if not resource_group or not name:
+        return ""
+    try:
+        view = client.virtual_machines.instance_view(resource_group, name)
+        return _power_state_from_statuses(getattr(view, "statuses", None))
+    except Exception as e:
+        log.warning("Instance view failed for VM %s: %s", name, e)
+        return ""
 
 
 def _get_os_type(vm) -> str:
@@ -34,15 +72,11 @@ def _get_os_type(vm) -> str:
     return ""
 
 
-def _get_status(vm) -> str:
-    try:
-        if vm.instance_view and vm.instance_view.statuses:
-            for s in vm.instance_view.statuses:
-                if s.code and s.code.startswith("PowerState/"):
-                    return s.code.replace("PowerState/", "")
-    except Exception:
-        pass
-    return "unknown"
+def _get_status(client, vm, states: dict, resource_group: str) -> str:
+    state = states.get(vm.id.lower(), "") if vm.id else ""
+    if not state:
+        state = _instance_view_power_state(client, resource_group, vm.name)
+    return state or "unknown"
 
 
 def main(subscription_id: str, subscription_name: str) -> None:
@@ -50,10 +84,15 @@ def main(subscription_id: str, subscription_name: str) -> None:
     if not utils.is_service_available_in_environment("compute", environment):
         sys.exit(0)
 
-    vms = collect_vms(subscription_id)
+    client = utils.get_azure_client("compute", subscription_id)
+    log.info("Listing all VMs in subscription %s", subscription_id)
+    vms = collect_vms(client)
     if not vms:
         print("No virtual machines found.")
         return
+
+    states = collect_power_states(client)
+    log.info("Resolved power state for %d of %d VMs from statusOnly listing", len(states), len(vms))
 
     rows = []
     for vm in vms:
@@ -73,7 +112,7 @@ def main(subscription_id: str, subscription_name: str) -> None:
                 and vm.storage_profile.image_reference.publisher
                 else ""
             ),
-            "Power State": _get_status(vm),
+            "Power State": _get_status(client, vm, states, rg),
             "Provisioning State": vm.provisioning_state or "",
             "Zones": ", ".join(vm.zones) if vm.zones else "",
             "Tags": "; ".join(f"{k}={v}" for k, v in tags.items()),

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,0 +1,176 @@
+"""Exporter unit tests — mocked Azure SDK models, no live Azure."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import advisor_export  # noqa: E402
+import virtual_machines_export as vm_export  # noqa: E402
+
+
+def _status(code):
+    return SimpleNamespace(code=code)
+
+
+def _vm(vm_id, name="vm1", statuses=None):
+    return SimpleNamespace(
+        id=vm_id,
+        name=name,
+        instance_view=SimpleNamespace(statuses=statuses) if statuses is not None else None,
+    )
+
+
+class _FakeVirtualMachines:
+    def __init__(self, status_only_vms=None, instance_views=None, status_only_error=None):
+        self._status_only_vms = status_only_vms or []
+        self._instance_views = instance_views or {}
+        self._status_only_error = status_only_error
+        self.status_only_calls = []
+        self.instance_view_calls = []
+
+    def list_all(self, status_only=None):
+        self.status_only_calls.append(status_only)
+        if self._status_only_error:
+            raise self._status_only_error
+        return iter(self._status_only_vms)
+
+    def instance_view(self, resource_group, name):
+        self.instance_view_calls.append((resource_group, name))
+        if (resource_group, name) not in self._instance_views:
+            raise RuntimeError("not found")
+        return self._instance_views[(resource_group, name)]
+
+
+class _FakeComputeClient:
+    def __init__(self, virtual_machines):
+        self.virtual_machines = virtual_machines
+
+
+# --- Finding 1: VM power state -------------------------------------------------
+
+
+def test_power_state_from_statuses_strips_prefix():
+    statuses = [_status("ProvisioningState/succeeded"), _status("PowerState/deallocated")]
+    assert vm_export._power_state_from_statuses(statuses) == "deallocated"
+
+
+def test_power_state_from_statuses_empty_is_blank():
+    assert vm_export._power_state_from_statuses(None) == ""
+    assert vm_export._power_state_from_statuses([]) == ""
+    assert vm_export._power_state_from_statuses([_status("ProvisioningState/succeeded")]) == ""
+
+
+def test_collect_power_states_uses_status_only_listing():
+    ops = _FakeVirtualMachines(
+        status_only_vms=[
+            _vm("/subs/x/vmA", "vmA", [_status("PowerState/deallocated")]),
+            _vm("/subs/x/vmB", "vmB", [_status("PowerState/running")]),
+        ]
+    )
+    states = vm_export.collect_power_states(_FakeComputeClient(ops))
+
+    assert ops.status_only_calls == ["true"]
+    assert states == {"/subs/x/vma": "deallocated", "/subs/x/vmb": "running"}
+
+
+def test_collect_power_states_survives_status_only_failure():
+    ops = _FakeVirtualMachines(status_only_error=RuntimeError("statusOnly unsupported"))
+    assert vm_export.collect_power_states(_FakeComputeClient(ops)) == {}
+
+
+def test_get_status_reads_the_state_map():
+    client = _FakeComputeClient(_FakeVirtualMachines())
+    vm = _vm("/subs/x/vmA", "vmA")
+    states = {"/subs/x/vma": "deallocated"}
+
+    assert vm_export._get_status(client, vm, states, "rg1") == "deallocated"
+    assert client.virtual_machines.instance_view_calls == []
+
+
+def test_get_status_falls_back_to_instance_view_when_missing_from_map():
+    view = SimpleNamespace(statuses=[_status("PowerState/stopped")])
+    ops = _FakeVirtualMachines(instance_views={("rg1", "vmA"): view})
+    vm = _vm("/subs/x/vmA", "vmA")
+
+    assert vm_export._get_status(_FakeComputeClient(ops), vm, {}, "rg1") == "stopped"
+    assert ops.instance_view_calls == [("rg1", "vmA")]
+
+
+def test_get_status_returns_unknown_only_when_both_paths_fail():
+    ops = _FakeVirtualMachines()
+    vm = _vm("/subs/x/vmA", "vmA")
+    assert vm_export._get_status(_FakeComputeClient(ops), vm, {}, "rg1") == "unknown"
+
+
+def test_get_status_failure_is_isolated_to_one_vm():
+    view = SimpleNamespace(statuses=[_status("PowerState/running")])
+    ops = _FakeVirtualMachines(instance_views={("rg1", "vmB"): view})
+    client = _FakeComputeClient(ops)
+
+    assert vm_export._get_status(client, _vm("/subs/x/vmA", "vmA"), {}, "rg1") == "unknown"
+    assert vm_export._get_status(client, _vm("/subs/x/vmB", "vmB"), {}, "rg1") == "running"
+
+
+# --- Finding 2: Advisor savings ------------------------------------------------
+
+
+def test_extract_savings_splits_monthly_and_annual():
+    result = advisor_export._extract_savings(
+        {"savingsAmount": "237.5", "annualSavingsAmount": "2850", "savingsCurrency": "USD"}
+    )
+    assert result["Potential Savings (Monthly)"] == 237.5
+    assert result["Potential Savings (Annual)"] == 2850.0
+    assert result["Savings Currency"] == "USD"
+
+
+def test_extract_savings_annual_only_leaves_monthly_blank():
+    result = advisor_export._extract_savings({"annualSavingsAmount": "2850"})
+    assert result["Potential Savings (Monthly)"] == ""
+    assert result["Potential Savings (Annual)"] == 2850.0
+    assert result["Savings Currency"] == "USD"
+
+
+def test_extract_savings_accepts_estimated_annual_alias():
+    result = advisor_export._extract_savings({"estimatedAnnualSavings": "1200"})
+    assert result["Potential Savings (Annual)"] == 1200.0
+
+
+def test_extract_savings_carries_reservation_context():
+    result = advisor_export._extract_savings(
+        {
+            "savingsAmount": "100",
+            "term": "P3Y",
+            "lookbackPeriod": "30",
+            "region": "usgovvirginia",
+        }
+    )
+    assert result["Reservation Term"] == "P3Y"
+    assert result["Lookback (days)"] == 30.0
+    assert result["Region"] == "usgovvirginia"
+
+
+def test_extract_savings_keeps_unparseable_lookback_as_text():
+    result = advisor_export._extract_savings({"savingsAmount": "100", "lookbackPeriod": "P30D"})
+    assert result["Lookback (days)"] == "P30D"
+
+
+def test_extract_savings_blank_when_no_cost_data():
+    result = advisor_export._extract_savings({"someOtherKey": "value"})
+    assert result["Potential Savings (Monthly)"] == ""
+    assert result["Potential Savings (Annual)"] == ""
+    assert result["Savings Currency"] == ""
+
+
+def test_extract_savings_handles_empty_properties():
+    for empty in ({}, None):
+        result = advisor_export._extract_savings(empty)
+        assert result["Potential Savings (Monthly)"] == ""
+        assert result["Savings Currency"] == ""
+
+
+def test_extract_savings_ignores_non_numeric_amounts():
+    result = advisor_export._extract_savings({"savingsAmount": "N/A", "savingsCurrency": "USD"})
+    assert result["Potential Savings (Monthly)"] == ""
+    assert result["Savings Currency"] == ""


### PR DESCRIPTION
Implements Findings 1 and 2 from `.collab/audit/azure-cost-data-collection-gaps-07.28.2026.md`. Both are collector defects that emitted wrong or ambiguous data in every pull. Finding 3 (new `vm_metrics_export.py` collector) is **not** in this PR.

## Finding 1 — VM power state was always `unknown`

`scripts/virtual_machines_export.py`

`virtual_machines.list_all()` does not populate `instance_view`, so `_get_status()` hit its `except`/empty path on every VM and returned the literal `"unknown"` — 202 of 202 VMs in the 07.08.2026 FCC pull. This blocked deallocated/stopped-VM reclamation analysis entirely.

Power state now comes from a second, status-scoped listing joined to the inventory by resource id:

```python
vms = collect_vms(client)                    # full properties
states = collect_power_states(client)        # list_all(status_only="true") -> {id: state}
```

**Why two calls instead of one.** The audit proposed replacing the inventory call with `list_all(params={"statusOnly": "true"})`. Two corrections there:

1. The SDK exposes this as a keyword-only argument — `list_all(status_only="true")`. The `params=` form reaches the query string through generated kwargs plumbing but is undocumented internals.
2. The statusOnly payload is not guaranteed to carry the inventory properties this export also reads — `VM Size`, `OS Type`, `OS Image`, `Zones`, `Tags`. A straight swap risked silently blanking five columns to fix one, and a mocked unit test would not have caught it.

Keeping both listings costs **one extra API call per subscription**, not one per VM, and is immune to whichever properties the status payload omits. (`expand="instanceView"` is not an alternative — the SDK docstring restricts it to requests that also pass a valid `$filter`, and the only allowed filter is `virtualMachineScaleSet/id`.)

Degradation is graceful in both directions: a statusOnly failure falls through to the per-VM `instance_view()` path, and one failing VM no longer blanks the column for the rest. `"unknown"` now appears only when both paths genuinely return no power state.

## Finding 2 — Advisor savings period was ambiguous

`scripts/advisor_export.py`

`_extract_savings()` returned the first matching key and discarded which one it used, collapsing to a string like `"237 USD"`. A consumer could not tell monthly from annual — a 12x ambiguity across 65 cost recommendations totalling $13,197.

Replaced with explicit columns:

| Column | Source |
|---|---|
| `Potential Savings (Monthly)` | `savingsAmount`, `monthlySavingsAmount` |
| `Potential Savings (Annual)` | `annualSavingsAmount`, `estimatedAnnualSavings` |
| `Savings Currency` | `savingsCurrency` (default `USD`, only when an amount exists) |
| `Reservation Term` | `term` |
| `Lookback (days)` | `lookbackPeriod` |
| `Region` | `region` |

Values are emitted numerically so summing either column needs no string parsing. ARM returns `extendedProperties` values as strings, so parsing goes through a guarded `float()` cast — unparseable amounts stay blank rather than becoming `0`. Absent keys stay blank rather than being derived from the other period. The generic `savings` key from the old candidate list is deliberately dropped: its period is unknown, which is the exact ambiguity being fixed.

⚠️ **Breaking (output format):** the `Potential Savings` column is replaced. Anything consuming advisor-recommendations workbooks needs updating.

## Verification

- `tests/test_exporters.py` — 16 new tests covering both findings, including the statusOnly-failure path, the per-VM fallback, per-VM failure isolation, and non-numeric / partial / empty `extendedProperties`.
- Full suite: **43 passed** (16 existing utils + 11 bootstrap + 16 new).
- `ruff check` clean, `py_compile` clean on all three files.
- End-to-end mocked run of both `main()` functions, with the statusOnly payload deliberately stripped of inventory properties to prove the two-call join holds:

```
Name         VM Size OS Type Power State Zones
 vmA Standard_D4s_v3   Linux deallocated     1   <- from statusOnly map
 vmB Standard_D2s_v3   Linux     running     1   <- from statusOnly map
 vmC    Standard_B2s   Linux     stopped     1   <- per-VM instance_view fallback
```

**Not verified against live Azure** (no credentials locally). SDK call shapes were confirmed by inspecting the published `azure-mgmt-compute` wheel. Needs @monkizzle validation — a subscription with a known-deallocated VM should now show `deallocated`.

## Scope notes

- **No new dependencies.** `azure-mgmt-compute>=30.0.0` and `azure-mgmt-advisor>=9.0.0` are already pinned.
- Existing exports are not retro-corrected — a fresh pull is needed before the improved data can be consumed.
- Finding 3 (VM utilization collector) is deferred. Two open design questions first: per-VM `metrics.list` is ~202 ARM calls per pull against Monitor throttling limits, layered on a Run All that just had a Cloud Shell timeout fix (#102); and `MetricsOperations.list_at_subscription_scope()` may cover it in one call per region. The audit's note to add a `monitor` entry to `_CLIENT_MAP` is already resolved — `utils.py:479`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)